### PR TITLE
refact scion init

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -54,7 +54,7 @@ def multi_token_cross_entropy_loss(
     main_loss = loss_fn(preds[0], labels[:, : job_config.training.seq_len])
 
     mtp_loss = 0
-    for (label_offset, pred) in enumerate(preds[1:], 1):
+    for label_offset, pred in enumerate(preds[1:], 1):
         loss = loss_fn(
             pred,
             labels[:, label_offset : label_offset + job_config.training.seq_len],

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -54,7 +54,7 @@ def multi_token_cross_entropy_loss(
     main_loss = loss_fn(preds[0], labels[:, : job_config.training.seq_len])
 
     mtp_loss = 0
-    for label_offset, pred in enumerate(preds[1:], 1):
+    for (label_offset, pred) in enumerate(preds[1:], 1):
         loss = loss_fn(
             pred,
             labels[:, label_offset : label_offset + job_config.training.seq_len],

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -5,11 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
-import os
 import queue
-import re
 import threading
-from collections import OrderedDict
 from typing import Any, Callable, Generic, Iterator, TypeVar
 
 import torch
@@ -26,9 +23,14 @@ from torch.optim import Optimizer
 from torchtitan.components.ft import FTManager, has_torchft
 from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.optimizers import DistributedScion, naive_param_norm, Scion
+from torchtitan.optimizers import (
+    create_disco_optimizer_kwargs_from_optimizer_config,
+    create_disco_param_groups,
+    DiSCO,
+    naive_param_norm,
+)
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import Color
+
 
 __all__ = [
     "OptimizersContainer",
@@ -42,55 +44,6 @@ if has_torchft:
 
 
 T = TypeVar("T", bound=Optimizer)
-
-
-def _extract_param_groups(
-    model: torch.nn.Module,
-    optimizer_config: dict[str, Any] | None = None,
-):
-    param_groups_config: list[dict[str, Any]] | None = (
-        optimizer_config.pop("param_groups", None)
-        if optimizer_config is not None
-        else None
-    )
-    if param_groups_config is None:
-        param_groups_config = []
-
-    param_dict = OrderedDict(
-        (n, p) for n, p in model.named_parameters() if p.requires_grad
-    )
-    params = []
-
-    color = Color()
-    for param_group_config in param_groups_config:
-        str_match = param_group_config.pop("param_str_match")
-        filter_fn = functools.partial(re.search, str_match)
-        param_names = [n for n in param_dict.keys() if filter_fn(n)]
-        group_params = {
-            "params": [param_dict.pop(n) for n in param_names],
-            "param_names": param_names,
-        }
-        assert len(group_params["params"]) == len(group_params["param_names"])
-
-        if len(param_names) == 0:
-            logger.warning(
-                f'{color.red}Notice: No parameters found for `str_match` "{str_match}" on '
-                f"global rank {torch.distributed.get_rank()}{color.reset}"
-            )
-            continue
-        group_params.update(param_group_config)
-        params.append(group_params)
-
-    param_names = list(param_dict.keys())
-    params.insert(
-        0,
-        {
-            "params": [param_dict.pop(n) for n in param_names],
-            "param_names": param_names,
-        },
-    )
-    assert not param_dict
-    return params
 
 
 class OptimizersContainer(Optimizer, Stateful, Generic[T]):
@@ -131,7 +84,6 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
-        param_groups_config = optimizer_kwargs.get("param_groups", None)
         # Whether to keep old LR values when loading.
         self.preserve_lrs_when_loading = False
         self.norms_to_log: list[str] | None = None
@@ -139,29 +91,15 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
         self.log_thread: threading.Thead | None = None
 
         for model in self.model_parts:
-            # copy parts we will pop from to preserve settings across model parts
-            kwargs = optimizer_kwargs.copy()
-            if "param_groups" in optimizer_kwargs:
-                kwargs["param_groups"] = (
-                    param_groups_config.copy()
-                    if param_groups_config is not None
-                    else None
+            if issubclass(optimizer_cls, DiSCO):
+                params, optimizer_kwargs = create_disco_param_groups(
+                    model, optimizer_kwargs
                 )
-
-            extra_kwargs = kwargs.pop("extra_kwargs")
-            params = _extract_param_groups(model, kwargs)
-
-            is_scion = issubclass(optimizer_cls, (Scion, DistributedScion))
-            if is_scion:
-                kwargs.update(extra_kwargs)
-            self.optimizers.append(optimizer_cls(params, **kwargs))
+            else:
+                params = [p for p in model.parameters() if p.requires_grad]
+            self.optimizers.append(optimizer_cls(params, **optimizer_kwargs))
             all_params.extend(params)
         self._validate_length(len(self.model_parts))
-        # Do not separately save the external settings in
-        # optimizer defaults.
-        optimizer_kwargs.pop("param_groups", None)
-        optimizer_kwargs.update(optimizer_kwargs.pop("extra_kwargs", {}))
-
         self._post_init(all_params, optimizer_kwargs)
 
     def __iter__(self) -> Iterator[T]:
@@ -176,12 +114,7 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
 
     def zero_grad(self, *args, **kwargs) -> None:
         for optimizer in self.optimizers:
-            if not (
-                isinstance(optimizer, (Scion, DistributedScion))
-                and optimizer.is_light
-                and optimizer.use_momentum
-            ):
-                optimizer.zero_grad(*args, **kwargs)
+            optimizer.zero_grad(*args, **kwargs)
 
     def state_dict(self) -> dict[str, Any]:
         func = functools.partial(
@@ -220,11 +153,11 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
                         param_group["lr"] = prev_lr
 
     def calculate_norm_at_next_step(self):
-        # for Dist-scion, we tell the optimizer to calculate the norm at next step
+        # for Disco, we tell the optimizer to calculate the norm at next step
         # in the step() function
         for i, _ in enumerate(self.model_parts):
             optimizer = self.optimizers[i]
-            if isinstance(optimizer, DistributedScion):
+            if isinstance(optimizer, DiSCO):
                 optimizer.calculate_norm_at_next_step(self.norms_to_log)
 
     def get_parameter_norms(self):
@@ -233,7 +166,7 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
             # NB: assumes correspondences between model parts and optimizers
             optimizer = self.optimizers[i]
             for group in optimizer.param_groups:
-                if isinstance(optimizer, DistributedScion):
+                if isinstance(optimizer, DiSCO):
                     all_norms.update(optimizer.get_norms_at_current_step())
                 else:
                     all_norms.update(
@@ -440,16 +373,12 @@ def build_optimizers(
                 "TorchFT is not supported with optimizers in backward."
             )
 
-    extra_kwargs = extra_kwargs if extra_kwargs is not None else {}
-
     name = optimizer_config.name
     lr = optimizer_config.lr
     beta1 = optimizer_config.beta1
     beta2 = optimizer_config.beta2
     eps = optimizer_config.eps
     weight_decay = optimizer_config.weight_decay
-
-    is_scion = name == "Scion" or name == "DistributedScion"
 
     width_multiplier = 1
     if name in ["Adam", "AdamW"]:
@@ -458,10 +387,6 @@ def build_optimizers(
 
         fused = optim_implementation == "fused"
         foreach = optim_implementation == "foreach"
-
-        if parallel_dims.ep_enabled:
-            # Because for Expert Parallel, we have two different device meshes.
-            fused, foreach = False, False
 
         width_multiplier = optimizer_config.mup_width_multiplier
 
@@ -474,102 +399,17 @@ def build_optimizers(
             "fused": fused,
             "foreach": foreach,
         }
-    elif is_scion:
-        backend_steps = optimizer_config.backend_steps
-        zeropower_backend_algorithm = optimizer_config.zeropower_backend
-        momentum = optimizer_config.momentum
-        nesterov = optimizer_config.nesterov
-        is_light = optimizer_config.is_light
-        weight_decay = optimizer_config.weight_decay
-        if os.environ.get("SCION_DEBUG_GRAD") == "1":
-            # only if we want to debug the gradient, we dont run SVD
-            norm_factor = "none"
-            zeropower_backend_algorithm = "identity"
-            logger.warning(
-                '`SCION_DEBUG_GRAD` is set to 1, we will not run SVD and use the "identity" backend'
-            )
-        else:
-            norm_factor = "spectral"
-
-        optimizer_kwargs = {
-            "is_light": is_light,
-            "weight_decay": weight_decay,
-            "lr": lr,
-            "momentum": momentum,
-            "nesterov": nesterov,
-            "eps": eps,
-            "norm_factor": norm_factor,
-            "backend": zeropower_backend_algorithm,
-            "backend_steps": backend_steps,
-        }
+    elif name in ["DiSCO"]:
+        optimizer_kwargs = create_disco_optimizer_kwargs_from_optimizer_config(
+            optimizer_config, parallel_dims
+        )
     else:
         raise NotImplementedError(f"Optimizer {name} not added.")
-
-    # Configure parameter group settings
-    embed_lr = optimizer_config.embed_lr
-    embed_str_match = optimizer_config.embed_str_match
-    if embed_lr is not None and embed_str_match:
-        param_groups_config = optimizer_kwargs.setdefault("param_groups", [])
-        param_group_config = {
-            "param_str_match": embed_str_match,
-            "lr": embed_lr,
-        }
-        if is_scion:
-            param_group_config["norm_factor"] = "embed_sqrt"
-            param_group_config["backend"] = "identity"
-        param_groups_config.append(param_group_config)
-    unembed_lr = optimizer_config.unembed_lr
-    unembed_str_match = optimizer_config.unembed_str_match
-    if unembed_lr is not None and unembed_str_match:
-        param_groups_config = optimizer_kwargs.setdefault("param_groups", [])
-        param_group_config = {
-            "param_str_match": unembed_str_match,
-            "lr": unembed_lr / width_multiplier,
-        }
-        if is_scion:
-            param_group_config["norm_factor"] = "unembed_sqrt"
-            param_group_config["backend"] = "identity"
-        param_groups_config.append(param_group_config)
-
-    router_str_match = optimizer_config.router_str_match
-    if router_str_match:
-        param_groups_config = optimizer_kwargs.setdefault("param_groups", [])
-        param_group_config = {
-            "param_str_match": router_str_match,
-            "lr": lr,
-        }
-        if is_scion:
-            # param_group_config["norm_factor"] = "image_spectral"
-            # param_group_config["backend"] = zeropower_backend_algorithm
-            # param_group_config["norm_factor"] = "none"
-            # param_group_config["backend"] = "identity"
-            param_group_config["norm_factor"] = "spectral"
-            param_group_config["backend"] = zeropower_backend_algorithm
-        param_groups_config.append(param_group_config)
-
-    # We automatically scale the SSNorm's scalar factor.
-    ss_norm_str_match = "ssnorm_scale"
-    if ss_norm_str_match:
-        param_groups_config = optimizer_kwargs.setdefault("param_groups", [])
-        param_group_config = {
-            "param_str_match": ss_norm_str_match,
-            "lr": lr,
-        }
-        if is_scion:
-            param_group_config["norm_factor"] = "sign"
-            param_group_config["backend"] = "identity"
-        param_groups_config.append(param_group_config)
-
-    optimizer_kwargs["extra_kwargs"] = {
-        "parallel_dims": parallel_dims,
-        **extra_kwargs,
-    }
 
     optimizer_classes = {
         "Adam": torch.optim.Adam,
         "AdamW": torch.optim.AdamW,
-        "Scion": Scion,
-        "DistributedScion": DistributedScion,
+        "DiSCO": DiSCO,
     }
     if name not in optimizer_classes:
         raise NotImplementedError(f"Optimizer {name} not added.")

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -55,7 +55,7 @@ class Metrics:
     log all available norms. If "default" is specified, use the following:
     - "rms_to_rms"
     - "l1_to_rms"
-    - "rms_to_l1"
+    - "rms_to_inf"
     - "supremum"
     - "condition_number"
     """
@@ -144,7 +144,7 @@ class Model:
     factors.
     """
 
-    init_gate_as_residual = True
+    init_gate_as_residual: bool = True
     """Whether to initialize the GLU gate as if it was a residual layer."""
 
     final_out_init_fn_type: str = "trunc_normal"
@@ -248,32 +248,23 @@ class Optimizer:
     is_light: bool = False
     """Whether to use Scion's light (memory-saving) version"""
 
+    norm_factor: str = "spectral"
+    """Which norm factor to use"""
+
     zeropower_backend: str = "newtonschulz5"
     "Which `zeropower_backend` to use."
 
     backend_steps: int = 5
-    """Number of steps for the Scion backend"""
+    """Number of steps for the DiSCO backend"""
 
     momentum: float = 0.95
-    """Scion momentum to use"""
+    """DiSCO momentum to use"""
 
     nesterov: bool = False
-    """Whether to use Nesterov momentum in Scion"""
+    """Whether to use Nesterov momentum in DiSCO"""
 
-    embed_lr: float | None = None
-    """Embedding layer learning rate"""
-
-    unembed_lr: float | None = None
-    """Unembedding layer learning rate"""
-
-    embed_str_match: str | None = None
-    """String to match for embedding layer parameter group"""
-
-    unembed_str_match: str | None = None
-    """String to match for unembedding layer parameter group"""
-
-    router_str_match: str | None = None
-    """String to match for MoE router layer parameter group"""
+    extra_param_group_split_rules: list[dict[str, Any]] | None = None
+    """Extra parameter group splitting rules for DiSCO optimizers"""
 
     implementation: Literal["for-loop", "foreach", "fused"] = "fused"
     """

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import ast
 import importlib
 import os
+import re
 import sys
 
 from dataclasses import field, fields, is_dataclass, make_dataclass
@@ -21,6 +23,70 @@ except ModuleNotFoundError:
 from torchtitan.tools.logging import logger
 
 from .job_config import JobConfig
+
+
+def _deep_set(d: dict, path: list[str], value):
+    """Set d[path]=value; path segments support 'a' and 'a[3]'. Creates dicts/lists as needed."""
+    cur = d
+    for i, seg in enumerate(path):
+        m = re.fullmatch(r"([A-Za-z0-9_]+)(?:\[(\d+)\])?", seg)
+        if not m:
+            raise ValueError(f"Bad path segment: {seg}")
+        name, idx = m.group(1), m.group(2)
+        last = i == len(path) - 1
+
+        if idx is None:
+            if last:
+                cur[name] = value
+            else:
+                nxt = cur.get(name)
+                if not isinstance(nxt, dict):
+                    nxt = {}
+                    cur[name] = nxt
+                cur = nxt
+        else:
+            j = int(idx)
+            seq = cur.get(name)
+            if not isinstance(seq, list):
+                seq = []
+                cur[name] = seq
+            while len(seq) <= j:
+                seq.append({})
+            if last:
+                seq[j] = value
+            else:
+                if not isinstance(seq[j], dict):
+                    seq[j] = {}
+                cur = seq[j]
+
+
+def _extract_indexed_overrides(raw_args: list[str]):
+    """
+    Capture tokens like:
+      --optimizer.extra-splits-rules[0].lr=1e-3
+      --optimizer.extra_param_group_split_rules[1].backend=identity
+    Return (remaining_args, overrides) where overrides = [(path_segments, value), ...].
+
+    We only intercept tokens that have both '[' and '=' to avoid stealing normal flags.
+    We also normalise '-' to '_' in keys to match your Python/TOML keys.
+    """
+
+    def _literal_eval_safe(s: str):
+        try:
+            return ast.literal_eval(s)
+        except Exception:
+            return s  # keep string if not a Python literal
+
+    remaining, overrides = [], []
+    for a in raw_args:
+        if a.startswith("-") and "[" in a and "=" in a:
+            key, val = a.lstrip("-").split("=", 1)
+            key = key.replace("-", "_")  # normalise hyphens to underscores
+            path = key.split(".")
+            overrides.append((path, _literal_eval_safe(val)))
+        else:
+            remaining.append(a)
+    return remaining, overrides
 
 
 class ConfigManager:
@@ -44,7 +110,16 @@ class ConfigManager:
         self.register_tyro_rules(custom_registry)
 
     def parse_args(self, args: list[str] = sys.argv[1:]) -> JobConfig:
+        args, idx_overrides = _extract_indexed_overrides(args)
+
         toml_values = self._maybe_load_toml(args)
+
+        if toml_values is None:
+            toml_values = {}
+
+        for path, val in idx_overrides:
+            _deep_set(toml_values, path, val)
+
         config_cls = self._maybe_add_custom_args(args, toml_values)
 
         base_config = (

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -653,17 +653,6 @@ def build_hf_validation_dataloader(
         dataset=hf_ds,
         seq_len=seq_len,
         infinite=False,
-        dataset_inner_name=dataset_inner_name,
-        dataset_files=dataset_files,
-        dataset_split=dataset_split,
-        dataset_streaming=dataset_streaming,
-        dataset_key=dataset_key,
-    )
-
-    hf_ds = GreedyPackedDataset(
-        dataset=hf_ds,
-        seq_len=seq_len,
-        infinite=False,
     )
 
     return ParallelAwareDataloader(

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -654,6 +654,7 @@ def build_hf_validation_dataloader(
         seq_len=seq_len,
         infinite=False,
         dataset_inner_name=dataset_inner_name,
+        dataset_files=dataset_files,
         dataset_split=dataset_split,
         dataset_streaming=dataset_streaming,
         dataset_key=dataset_key,

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -171,6 +171,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         infinite: bool = False,
+        num_mtp_tokens: int = 0,
         dataset_inner_name: str | None = None,
         dataset_files: str | Sequence[str] | None = None,
         dataset_split: str = "train",
@@ -195,6 +196,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         self._data = split_dataset_by_node(ds, dp_rank, dp_world_size)
         self._tokenizer = tokenizer
         self.infinite = infinite
+        self.num_mtp_tokens = num_mtp_tokens
         self._text_processor = text_processor
 
         # Variables for checkpointing

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -553,7 +553,7 @@ def build_hf_dataloader(
             len(d) == normed_list_length
         ), f"list {d} does not match length of list of datasets (length = {normed_list_length})"
     hf_datasets = []
-    for (d_name, d_path, d_inner_name, d_split, d_key) in zip(
+    for d_name, d_path, d_inner_name, d_split, d_key in zip(
         dataset_name,
         dataset_path,
         dataset_inner_name,
@@ -653,6 +653,10 @@ def build_hf_validation_dataloader(
         dataset=hf_ds,
         seq_len=seq_len,
         infinite=False,
+        dataset_inner_name=dataset_inner_name,
+        dataset_split=dataset_split,
+        dataset_streaming=dataset_streaming,
+        dataset_key=dataset_key,
     )
 
     return ParallelAwareDataloader(

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -171,7 +171,6 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         infinite: bool = False,
-        num_mtp_tokens: int = 0,
         dataset_inner_name: str | None = None,
         dataset_files: str | Sequence[str] | None = None,
         dataset_split: str = "train",
@@ -196,7 +195,6 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         self._data = split_dataset_by_node(ds, dp_rank, dp_world_size)
         self._tokenizer = tokenizer
         self.infinite = infinite
-        self.num_mtp_tokens = num_mtp_tokens
         self._text_processor = text_processor
 
         # Variables for checkpointing
@@ -660,6 +658,12 @@ def build_hf_validation_dataloader(
         dataset_split=dataset_split,
         dataset_streaming=dataset_streaming,
         dataset_key=dataset_key,
+    )
+
+    hf_ds = GreedyPackedDataset(
+        dataset=hf_ds,
+        seq_len=seq_len,
+        infinite=False,
     )
 
     return ParallelAwareDataloader(

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -796,7 +796,7 @@ class Transformer(nn.Module, ModelProtocol):
             if self.norm and prev_embed is None:
                 prev_embed = h
 
-            for (mtp_layer_id, mtp_layer) in self.mtp_layers.items():
+            for mtp_layer_id, mtp_layer in self.mtp_layers.items():
                 mtp_layer_id = int(mtp_layer_id)
                 token_offset = mtp_layer_id + 1
                 output, prev_embed = mtp_layer(

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -736,9 +736,6 @@ class Transformer(nn.Module, ModelProtocol):
                 This will always be the input batch regardless of the pipeline stage.
                 This field is required for non-first PP stages to perform document
                 masking attention (to analyze the boundary of the document).
-            prev_embed (torch.Tensor | None): Output token embeddings of
-                previous Transformer layer (after output norm, before
-                unembedding).
 
         Returns:
             MTPInputsDict: Dictionary containing the following keys and

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -736,6 +736,9 @@ class Transformer(nn.Module, ModelProtocol):
                 This will always be the input batch regardless of the pipeline stage.
                 This field is required for non-first PP stages to perform document
                 masking attention (to analyze the boundary of the document).
+            prev_embed (torch.Tensor | None): Output token embeddings of
+                previous Transformer layer (after output norm, before
+                unembedding).
 
         Returns:
             MTPInputsDict: Dictionary containing the following keys and

--- a/torchtitan/optimizers/__init__.py
+++ b/torchtitan/optimizers/__init__.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .distributed_scion import DistributedScion  # noqa: F401
-from .scion import Scion  # noqa: F401
-from .utils import remove_orig_mod_and_weight_for_p_name  # noqa: F401
+from .abstract_disco import AbstractDiSCO  # noqa: F401
+from .distributed_scion import DiSCO  # noqa: F401
+from .utils import (  # noqa: F401  # noqa: F401  # noqa: F401
+    create_disco_optimizer_kwargs_from_optimizer_config,
+    create_disco_param_groups,
+    remove_orig_mod_and_weight_for_p_name,
+)

--- a/torchtitan/optimizers/abstract_disco.py
+++ b/torchtitan/optimizers/abstract_disco.py
@@ -1,0 +1,240 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.distributed.tensor import DTensor
+
+from .muon_utils import zeropower_backends
+from .norm_helper import NORM_FUNCTIONS
+
+__all__ = [
+    "AbstractDiSCO",
+]
+
+
+class AbstractDiSCO(torch.optim.Optimizer):
+    """
+    Shared utilities for Spectral Conditioned Optimizer.
+
+    This base class centralizes common functionality not specific to a
+    particular distributed layout, including:
+      - light-mode grad state save/load hooks
+      - zero_grad handling for light mode
+      - gradient normalisation helpers
+      - optional tracking of norms across steps
+    """
+
+    def __init__(self, params, defaults, is_light: bool = False):
+        # Initialize as a torch Optimizer and common state
+        super().__init__(params, defaults)
+        self.is_light: bool = is_light
+
+        # Norm tracking state
+        self.need_to_calculate_norm: bool = False
+        self.norms_to_log: list[str] = list(NORM_FUNCTIONS.keys())
+        self.norms_at_current_step: dict[str, torch.Tensor] = {}
+
+    # ----- Light mode hooks -----
+    def setup_light_state_hooks(self):
+        if not self.is_light:
+            return
+        # Initialize state immediately to capture existing grads
+        self._store_grads_in_state()
+        # Register hooks so grads persist through state_dict save/load
+        self.register_state_dict_pre_hook(type(self)._store_grads_in_state)
+        self.register_load_state_dict_post_hook(type(self)._load_grads_from_state)
+
+    def __getstate__(self):
+        self._store_grads_in_state()
+        return super().__getstate__()
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._load_grads_from_state()
+
+    def _store_grads_in_state(self, *args, **kwargs):
+        # args/kwargs present to allow hook-style invocation
+        for group in self.param_groups:
+            for param in group["params"]:
+                if isinstance(param, torch.Tensor) and param.grad is not None:
+                    self.state.setdefault(param, {})["grad_state"] = param.grad
+
+    def _load_grads_from_state(self, *args, **kwargs):
+        for param, state in self.state.items():
+            if "grad_state" in state:
+                param.grad = state["grad_state"]
+            elif isinstance(param, torch.Tensor):
+                param.grad = None
+
+    # ----- Step norm tracking -----
+    def calculate_norm_at_next_step(self, norms_to_log: list[str]):
+        self.need_to_calculate_norm = True
+        self.norms_to_log = norms_to_log
+        self.norms_at_current_step = {}
+
+    def _is_logging_rank(self) -> bool:
+        # Subclasses can override this to restrict logging to rank 0
+        return True
+
+    def get_norms_at_current_step(self):
+        if self._is_logging_rank():
+            return self.norms_at_current_step
+        else:
+            return {}
+
+    def zero_grad(self, *args, **kwargs):
+        # Preserve grads for light mode; otherwise use default behavior
+        if self.is_light:
+            return
+        super().zero_grad(*args, **kwargs)
+
+    @staticmethod
+    @torch.no_grad()
+    @torch.compile(fullgraph=True)
+    def normalise_grad(g: torch.Tensor, norm_factor: str, eps: float):
+        """
+        Normalises a gradient tensor. Handles both 2D [d_out, d_in] and
+        3D [n_experts, d_out, d_in] tensors.
+        """
+        if norm_factor == "spectral":
+            # Use the last two dims so this works for 2-D and batched 3-D
+            g = g * (g.size(-2) / g.size(-1)) ** 0.5
+
+        elif norm_factor == "image_spectral":
+            ratio = (g.size(-2) / g.size(-1)) ** 0.5
+            g = g * (ratio if ratio > 1 else 1)
+
+        elif norm_factor.startswith("embed"):
+            # Handle 2-D and batched 3-D consistently
+            assert g.ndim == 2
+            if g.ndim == 2:
+                rms_values = torch.sqrt(g.pow(2).sum(dim=1, keepdim=True))
+                dim = g.size(1)
+            else:
+                raise ValueError("embed* expects 2-D ")
+            g = g / (rms_values + eps)
+            if norm_factor == "embed_linear":
+                g = g * dim
+            elif norm_factor == "embed_sqrt":
+                g = g * dim**0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        elif norm_factor.startswith("unembed"):
+            assert g.ndim == 2
+            if g.ndim == 2:
+                rms_values = torch.sqrt(g.pow(2).sum(dim=1, keepdim=True))
+                dim = g.size(1)
+            else:
+                raise ValueError("unembed* expects 2-D ")
+            g = g / (rms_values + eps)
+            if norm_factor == "unembed_linear":
+                g = g / dim
+            elif norm_factor == "unembed_sqrt":
+                g = g / dim**0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        elif norm_factor == "sign":
+            g = torch.sign(g)
+
+        elif norm_factor == "bias_rms":
+            rms_value = torch.sqrt(g.pow(2).mean())
+            g = g / (rms_value + eps)
+
+        elif norm_factor == "conv_spectral":
+            # Properly handle Conv2D (4-D) and Conv3D (5-D)
+            if g.ndim == 4:
+                out_ch, in_ch, kh, kw = g.shape
+                spatial = kh * kw
+            elif g.ndim == 5:
+                out_ch, in_ch, kh, kw, kd = g.shape
+                spatial = kh * kw * kd
+            else:
+                raise ValueError("conv_spectral expects 4-D or 5-D conv weights")
+            g *= (out_ch / in_ch) ** 0.5 / spatial
+
+        elif norm_factor == "none":
+            pass
+        else:
+            raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        return g
+
+    @staticmethod
+    @torch.no_grad()
+    def lmo(
+        g,
+        eps,
+        norm_factor,
+        zeropower_backend,
+        backend_steps,
+        transpose_experts=False,
+    ):
+        """Supported Weight Types:
+        - 1-D tensors: Bias vectors (Linear/Convolution layers)
+        - 2-D tensors: Linear layer weights [D_out, D_in]
+        - 3-D tensors: Grouped expert weights [G, D_in, D_out] or [G, D_out, D_in]
+        - 4-D tensors: Conv2D weights [D_out, D_in, KH, KW] (forced to "conv_spectral")
+        - 5-D tensors: Conv3D weights [D_out, D_in, KH, KW, KD] (forced to "conv_spectral")
+
+        Limitations:
+        - Does not support learnable RMS/Layer-norm parameters
+        - Does not support shared experts or Fused GLU in format [D_in, D_out * M], where M > 1
+        - Does not support Conv1D layers Note:
+        - For 3-D expert weights, the layout must be specified during optimizer initialization.
+
+
+        * 0-D (scalar) weights is supported but should not appear in this function call
+        """
+
+        g = g.to_local() if isinstance(g, DTensor) else g
+
+        # NB: make sure this function does not modify the grad inplace
+        #     since it is also called during the log of gradients
+        def _orth_and_norm(x):
+            x = zeropower_backends[zeropower_backend](x, steps=backend_steps, eps=eps)
+            x = AbstractDiSCO.normalise_grad(x, norm_factor=norm_factor, eps=eps)
+            return x
+
+        if g.ndim == 2:
+            return _orth_and_norm(g)
+
+        # 3-D: batched experts [G, D_out, D_in] (or [G, D_in, D_out] if transposed)
+        elif g.ndim == 3:
+            if g.shape[0] > 0:
+                g = g.transpose(1, 2) if transpose_experts else g
+                g = _orth_and_norm(
+                    g
+                )  # backend is batched; normaliser uses last two dims
+                g = g.transpose(1, 2) if transpose_experts else g
+            return g  # empty G==0 falls through unchanged
+
+        # 1-D: bias vector
+        elif g.ndim == 1:
+            if zeropower_backend == "bias_rms" or norm_factor == "bias_rms":
+                # cheap bias path
+                return AbstractDiSCO.normalise_grad(g, norm_factor="bias_rms", eps=eps)
+            # generic: lift to diagonal, apply 2-D logic, project back
+            g_diag = torch.diag_embed(g).contiguous()
+            g_diag = _orth_and_norm(g_diag)
+            return g_diag.diagonal().contiguous()
+
+        # 4-D/5-D: conv weights; flatten spatial dims into 'in' dim
+        elif g.ndim == 4 or g.ndim == 5:
+            shape = g.shape
+            g2d = g.reshape(shape[0], -1)  # [D_out, D_in*prod(K)]
+            g2d = zeropower_backends[zeropower_backend](
+                g2d, steps=backend_steps, eps=eps
+            )
+            # force conv-specific scaling
+            g2d = AbstractDiSCO.normalise_grad(
+                g2d.view(shape), norm_factor="conv_spectral", eps=eps
+            )
+            return g2d.view(shape)
+
+        else:
+            raise ValueError(f"Unknown grad shape: {g.shape}")

--- a/torchtitan/optimizers/distributed_scion.py
+++ b/torchtitan/optimizers/distributed_scion.py
@@ -5,24 +5,41 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+import os
+from collections import defaultdict
 from enum import Enum
-from functools import partial
 
 import torch
 import torch.distributed as dist
-import torch.distributed.tensor
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import _StridedShard, Replicate, Shard
 
 from torchtitan.tools.logging import logger
+from .abstract_disco import AbstractDiSCO
 
-from .muon_utils import zeropower_backends
-from .norm_helper import calculate_norm, NORM_FUNCTIONS
+try:
+    import torch.distributed._symmetric_memory as _sm_mod
+except ImportError:
+    _sm_mod = None
+
+from torch.profiler import record_function  # labels in PyTorch profiler
+
+from .norm_helper import calculate_norm
 from .utils import remove_orig_mod_and_weight_for_p_name
 
 __all__ = [
-    "DistributedScion",
+    "DiSCO",
 ]
+
+
+# these variables are hardcoded for now, taken from torchtitan
+CONST_NAME_OF_EMBEDDING = "tok_embeddings"
+
+# Environment variables and default values
+# DISCO_DEBUG_MODE = "0"
+# DISCO_ENABLE_NVSHMEM = "0"
+# DISCO_NVSHMEM_PARAMS_PER_BUFFER = "4"
+# DISCO_NVSHMEM_FSDP_COMPUTE_STREAMS = "2"
 
 
 class ParamType(Enum):
@@ -36,16 +53,18 @@ def get_param_type(p, fsdp_enabled, expert_enabled):
     """
     We can aggressively assume that the param is FSDP-Sharded
     """
-    if p.grad is None:
-        return ParamType.Unknown
-    if not fsdp_enabled and not expert_enabled and isinstance(p, torch.Tensor):
+    # if p.grad is None:
+    #     return ParamType.Unknown
+    if p.numel() == 1:
+        # treat scalars separately in _build_param_lists(); return DDP here by default
         return ParamType.DDP
-    if p.ndim == 3:
+    if p.ndim == 3 and (expert_enabled or fsdp_enabled):
+        # in torchtitan, one EP is enabled, FSDP is automatically enabled
+        # here just for compatibility
         return ParamType.Expert
-    elif fsdp_enabled:
+    if fsdp_enabled:
         return ParamType.FSDP
-    else:
-        return ParamType.Unknown
+    return ParamType.DDP
 
 
 def tp_axis(placements: tuple, tp_enabled: bool = False) -> int | None:
@@ -77,7 +96,7 @@ def tp_axis(placements: tuple, tp_enabled: bool = False) -> int | None:
 def gather_tp_shard(tensor, tp_group, tp_world_size, original_placements):
     # TP is used, we need to gather the TP-shard params first
     tp_mesh_dim = tp_axis(original_placements, True)
-    assert tp_mesh_dim is not None, "something wrong here"
+    assert tp_mesh_dim is not None, "TP mesh dimension not found"
     shard_dim = original_placements[tp_mesh_dim].dim
 
     output_tensors = [torch.empty_like(tensor) for _ in range(tp_world_size)]
@@ -96,7 +115,7 @@ def calculate_shard_shape(shape, rank, world_size):
     return (dim0, *shape[1:])
 
 
-class DistributedScion(torch.optim.Optimizer):
+class DiSCO(AbstractDiSCO):
     def __init__(
         self,
         params,
@@ -114,11 +133,13 @@ class DistributedScion(torch.optim.Optimizer):
         extra_reduce_for_HSDP=False,
         experts_weights_layout="G-D_out-D_in",
     ):
-        self.need_to_calculate_norm = False
-        self.norms_to_log: list[str] = list(NORM_FUNCTIONS.keys())
-        self.norms_at_current_step = {}
+
+        debug_mode = os.environ.get("DISCO_DEBUG_MODE", "0") == "1"
+
+        # Initialize base optimizer and common state
         self.extra_reduce_for_HSDP = False
         self.log_parameters_types = True
+        self.is_light = is_light
 
         defaults = dict(
             lr=lr,
@@ -126,11 +147,11 @@ class DistributedScion(torch.optim.Optimizer):
             weight_decay=weight_decay,
             nesterov=nesterov,
             eps=eps,
-            norm_factor=norm_factor,
-            backend=backend,
+            norm_factor=norm_factor if not debug_mode else "none",
+            backend=backend if not debug_mode else "identity",
             backend_steps=backend_steps,
         )
-        self.is_light = is_light
+        assert is_light is False, "is_light must be False"
 
         is_unconstrained = weight_decay == 0
 
@@ -142,7 +163,11 @@ class DistributedScion(torch.optim.Optimizer):
         self.tp_enabled = parallel_dims.tp_enabled
 
         # this is used to ensure only the DP or FSDP rank 0 will have norms
-        self.is_dp_rank_0 = dist.get_rank(self.world_mesh["dp_cp"].get_group()) == 0
+        if self.dp_replicate_enabled or self.fsdp_enabled:
+            self.is_dp_rank_0 = dist.get_rank(self.world_mesh["dp_cp"].get_group()) == 0
+        else:
+            # only PP (and/or) TP enabled
+            self.is_dp_rank_0 = dist.get_rank() == 0
 
         assert experts_weights_layout in [
             "G-D_in-D_out",
@@ -152,24 +177,15 @@ class DistributedScion(torch.optim.Optimizer):
         self.extra_reduce_for_HSDP = extra_reduce_for_HSDP
 
         logger.info(
-            f"Distributed Scion optimizer "
+            f"Distributed Spectral Conditioned Optimizer "
             f"(is_light={self.is_light}, is_unconstrained={is_unconstrained}) "
             f"is enabled with world_mesh={self.world_mesh} | fsdp_enabled={self.fsdp_enabled} | "
             f"EP={self.expert_enabled} | TP={self.tp_enabled} | DP={self.dp_replicate_enabled}"
         )
 
-        super().__init__(params, defaults)
-        if self.is_light:
-            # Initialize state
-            self._store_grads_in_state()
-            # Do not pass `self` through syntactic sugar. We need the
-            # argument to not be populated.
-            self.register_state_dict_pre_hook(
-                type(self)._store_grads_in_state,
-            )
-            self.register_load_state_dict_post_hook(
-                type(self)._load_grads_from_state,
-            )
+        super().__init__(params, defaults, is_light=is_light)
+        # Register light-mode grad state hooks if needed
+        self.setup_light_state_hooks()
 
         self.communication_dtype = communication_dtype
         self.groups_info = {}
@@ -181,13 +197,22 @@ class DistributedScion(torch.optim.Optimizer):
             wd = group["weight_decay"]
             param_kwargs = {
                 "eps": group["eps"],
-                "norm_factor": group["norm_factor"],
-                "zeropower_backend": group["backend"],
+                "norm_factor": group["norm_factor"] if not debug_mode else "none",
+                "zeropower_backend": group["backend"] if not debug_mode else "identity",
                 "backend_steps": group["backend_steps"],
             }
             self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
             for param in group["params"]:
                 self.parameters_to_groups[id(param)] = group_idx
+
+                if (
+                    param.ndim == 3
+                    and self.expert_enabled
+                    and Shard(1) in param.placements
+                ):
+                    raise NotImplementedError(
+                        "we should now allow the Shard(1) for grouped experts"
+                    )
 
                 # check sanity of MoE, do not allow the Shard(1) for grouped experts
                 if (
@@ -199,38 +224,144 @@ class DistributedScion(torch.optim.Optimizer):
                         "we should now allow the Shard(1) for grouped experts"
                     )
 
+            logger.info(
+                f"group_idx: {group_idx} || lr: {lr} || nesterov: {nesterov} || momentum: {momentum} || wd: {wd} || {param_kwargs}"
+            )
+
             if self.is_light and nesterov:
                 raise RuntimeError(
-                    "Nesterov momentum is not supported for Scion's light mode. "
+                    "Nesterov momentum is not supported for spectral conditioned optimizer's light mode. "
                     "Please set nesterov=False."
                 )
 
-    def calculate_norm_at_next_step(self, norms_to_log: list[str]):
-        self.need_to_calculate_norm = True
-        self.norms_to_log = norms_to_log
-        self.norms_at_current_step = {}
+        # public caches
+        self.scale_params, self.scale_param_names = [], []
+        self.embed_params, self.embed_param_names = [], []
+        self.ddp_params, self.ddp_param_names = [], []
+        self.fsdp_params, self.fsdp_param_names = [], []
+        self.expert_params, self.expert_param_names = [], []
+        # build once now
+        self._build_param_lists()
 
-    def get_norms_at_current_step(self):
-        if self.is_dp_rank_0:
-            return self.norms_at_current_step
-        else:
-            return {}
+        # check if nvshmem is enabled and build the workspace if FSDP is enabled
+        disable_nvshmem = os.environ.get("DISCO_ENABLE_NVSHMEM", "0") == "0"
+        self.disable_nvshmem = disable_nvshmem or _sm_mod is None
 
+    def _build_param_lists(self):
+        # clear
+        self.scale_params.clear()
+        self.scale_param_names.clear()
+        self.embed_params.clear()
+        self.embed_param_names.clear()
+        self.ddp_params.clear()
+        self.ddp_param_names.clear()
+        self.fsdp_params.clear()
+        self.fsdp_param_names.clear()
+        self.expert_params.clear()
+        self.expert_param_names.clear()
+
+        # decide embedding per-group exactly like in step()
+        # (backend == "identity" and norm_factor startswith embed/unembed)
+        def _is_embed_group(g):
+            nf, be = g["norm_factor"], g["backend"]
+            return (be == "identity") and (
+                nf.startswith("embed") or nf.startswith("unembed")
+            )
+
+        for group in self.param_groups:
+            route_to_embed = _is_embed_group(group)
+            for p_name, p in zip(group["param_names"], group["params"]):
+                if not p.requires_grad:
+                    # ignore the non-trainable parameters
+                    continue
+
+                # 1) scalar branch identical to step()
+                if p.numel() == 1:
+                    assert (
+                        group["backend"] == "identity"
+                    ), "scale params must use identity backend"
+                    assert (
+                        group["norm_factor"] == "sign"
+                    ), "scale params must use sign norm factor"
+                    self.scale_params.append(p)
+                    self.scale_param_names.append(p_name)
+                    continue
+                # 2) embedding fast path identical to step() predicate
+                if route_to_embed:
+                    self.embed_params.append(p)
+                    self.embed_param_names.append(p_name)
+                    continue
+                # 3) structural type without reading p.grad (init-time)
+                ptype = get_param_type(p, self.fsdp_enabled, self.expert_enabled)
+                if ptype == ParamType.DDP:
+                    self.ddp_params.append(p)
+                    self.ddp_param_names.append(p_name)
+                elif ptype == ParamType.FSDP:
+                    self.fsdp_params.append(p)
+                    self.fsdp_param_names.append(p_name)
+                elif ptype == ParamType.Expert:
+                    self.expert_params.append(p)
+                    self.expert_param_names.append(p_name)
+                else:
+                    # static classifier should not return Unknown
+                    pass
+        if self.ddp_params:
+            pairs = list(zip(self.ddp_params, self.ddp_param_names))
+            # sort big → small to reduce padding and make buckets well-conditioned
+            pairs.sort(key=lambda x: x[0].numel(), reverse=True)
+
+            # snake interleave across buckets to balance per-rank Phase-A compute
+            dp_group = (
+                self.world_mesh["dp_replicate"].get_group()
+                if self.dp_replicate_enabled
+                else None
+            )
+            w = dp_group.size() if dp_group is not None else 1
+            if w > 1:
+                blocks = [pairs[i : i + w] for i in range(0, len(pairs), w)]
+                for b, blk in enumerate(blocks):
+                    if b % 2 == 1:
+                        blk.reverse()
+                pairs = [p for blk in blocks for p in blk]
+
+            self.ddp_params, self.ddp_param_names = (
+                (list(t) if pairs else [] for t in zip(*pairs)) if pairs else ([], [])
+            )
+
+        if self.fsdp_params:
+            pairs = list(zip(self.fsdp_params, self.fsdp_param_names))
+            pairs.sort(key=lambda x: x[0].numel(), reverse=True)
+            self.fsdp_params, self.fsdp_param_names = list(zip(*pairs))
+            self.fsdp_params, self.fsdp_param_names = list(self.fsdp_params), list(
+                self.fsdp_param_names
+            )
+
+        if self.expert_params:
+            pairs = list(zip(self.expert_params, self.expert_param_names))
+            pairs.sort(key=lambda x: (x[0].numel(), x[0].shape[1]), reverse=True)
+            self.expert_params, self.expert_param_names = list(zip(*pairs))
+            self.expert_params, self.expert_param_names = list(
+                self.expert_params
+            ), list(self.expert_param_names)
+
+        if self.log_parameters_types:
+            logger.info(
+                f"fsdp_params: {len(self.fsdp_params)} | expert_params: {len(self.expert_params)} | "
+                f"ddp_params: {len(self.ddp_params)} | embed_params: {len(self.embed_params)} | "
+                f"scale_params: {len(self.scale_params)}"
+            )
+            self.log_parameters_types = False
+
+    @record_function("disco.step")
     @torch.no_grad()
     def step(self, closure=None):
         loss = None
         if closure is not None:
             with torch.enable_grad():
                 loss = closure()
-        scale_params, scale_param_names = [], []
-        embed_params, embed_param_names = [], []
-        ddp_params, ddp_param_names = [], []
-        fsdp_params, fsdp_param_names = [], []
-        expert_params, expert_param_names = [], []
 
+        # only refresh schedulables each step (unchanged behaviour)
         for group_idx, group in enumerate(self.param_groups):
-            # we should update self.groups_info here incase we have LR and momentum scheduler
-            # We can also optionally do norm_factor and backend scheduler if we want to
             lr = group["lr"]
             nesterov = group["nesterov"]
             momentum = group["momentum"]
@@ -243,239 +374,26 @@ class DistributedScion(torch.optim.Optimizer):
             }
             self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
 
-            for p_name, p in zip(group["param_names"], group["params"]):
-                norm_factor = group["norm_factor"]
-                backend = group["backend"]
-                is_embed_norm = norm_factor.startswith(
-                    "embed"
-                ) or norm_factor.startswith("unembed")
+        self.prepare_gradients_and_momentum()
 
-                if p.numel() == 1:
-                    assert (
-                        backend == "identity"
-                    ), "scale params must use identity backend"
-                    assert (
-                        norm_factor == "sign"
-                    ), "scale params must use sign norm factor"
-                    scale_params.append(p)
-                    scale_param_names.append(p_name)
-                    continue
+        # If you ever flip routing (backend/norm_factor) and want new buckets, call self._build_param_lists() explicitly.
+        # Otherwise, just dispatch with the cached lists
 
-                if backend == "identity" and is_embed_norm:
-                    # for these Row/Col-wise norm, there is no need to gather the gradient
-                    embed_params.append(p)
-                    embed_param_names.append(p_name)
-                    continue
+        self.step_scalar(self.scale_params, self.scale_param_names)
+        self.step_embedding(self.embed_params, self.embed_param_names)
+        self.step_experts(self.expert_params, self.expert_param_names)
+        self.step_ddp(self.ddp_params, self.ddp_param_names)
 
-                param_type = get_param_type(p, self.fsdp_enabled, self.expert_enabled)
-                if param_type == ParamType.DDP:
-                    ddp_params.append(p)
-                    ddp_param_names.append(p_name)
-                elif param_type == ParamType.FSDP:
-                    fsdp_params.append(p)
-                    fsdp_param_names.append(p_name)
-                elif param_type == ParamType.Expert:
-                    expert_params.append(p)
-                    expert_param_names.append(p_name)
-                elif param_type == ParamType.Unknown:
-                    logger.warning(
-                        f"Unknown param type: {p_name}, p.shape {p.shape}, grad is None[?] "
-                        f"{p.grad is None}, the optimizer will skip this param"
-                    )
-                    # raise ValueError(f"Unknown param type: {p_name}")
-                    continue
-                else:
-                    raise ValueError("param_type")
+        if not self.disable_nvshmem:
+            self.step_fsdp_nvshmem(self.fsdp_params, self.fsdp_param_names)
+        else:
+            self.step_fsdp(self.fsdp_params, self.fsdp_param_names)
 
-        # Sort fsdp_params and their names together
-        fsdp_pairs = list(zip(fsdp_params, fsdp_param_names))
-        fsdp_pairs.sort(key=lambda x: x[0].numel(), reverse=True)
-        fsdp_params, fsdp_param_names = zip(*fsdp_pairs) if fsdp_pairs else ([], [])
-        # Sort expert_params and their names together
-        expert_pairs = list(zip(expert_params, expert_param_names))
-        expert_pairs.sort(key=lambda x: (x[0].numel(), x[0].shape[1]), reverse=True)
-        expert_params, expert_param_names = (
-            zip(*expert_pairs) if expert_pairs else ([], [])
-        )
-        if self.log_parameters_types:
-            # only log once
-            logger.info(
-                f"fsdp_params: {len(fsdp_params)} | expert_params: {len(expert_params)} | "
-                f"ddp_params: {len(ddp_params)} | embed_params: {len(embed_params)} | "
-                f"scale_params: {len(scale_params)}"
-            )
-            self.log_parameters_types = False
-
-        """
-        We could merge `embed_params` and `expert_params` into one list.
-        The diff is, we are sure expert_params have bunch of 2D full-matrixs
-        But we might need to gather the `embed_params` to 2D full-matrixs
-        if we wanna to get the norm of the gradient.
-        """
-        self.step_scalar(scale_params, scale_param_names)
-        self.step_embedding(embed_params, embed_param_names)
-        self.step_experts(expert_params, expert_param_names)
-        self.step_ddp(ddp_params, ddp_param_names)
-        self.step_fsdp(fsdp_params, fsdp_param_names)
-
-        # reset the flag for the next step
         self.need_to_calculate_norm = False
         return loss
 
-    @torch.no_grad()
-    def lmo(
-        self,
-        g,
-        eps,
-        norm_factor,
-        zeropower_backend,
-        backend_steps,
-    ):
-        g = g.to_local() if isinstance(g, DTensor) else g
-
-        # NB: make sure this function does not modify the grad inplace
-        #     since it is also called during the log of gradients
-        def _lmo_for_2d_tensor(g, need_transpose=False):
-            g = g if not need_transpose else g.transpose(0, 1)
-            g = zeropower_backends[zeropower_backend](g, steps=backend_steps, eps=eps)
-            g = self.normalise_grad(g, norm_factor=norm_factor, eps=eps)
-            return g if not need_transpose else g.transpose(0, 1)
-
-        if g.ndim == 2:
-            g = _lmo_for_2d_tensor(g, need_transpose=False)
-        elif g.ndim == 3:
-            if g.shape[0] > 0:
-                # When world_size [fsdp x EP] > Total number of experts,
-                # some ranks may have 0 experts that shape will be [0, d-in, d-out]
-                # We should return the original grad here and **do not** do stack
-                g = torch.stack(
-                    [
-                        _lmo_for_2d_tensor(
-                            g[i], need_transpose=self.experts_need_transpose
-                        )
-                        for i in range(g.shape[0])
-                    ],
-                    dim=0,
-                )
-            else:
-                pass
-        elif g.ndim == 1:
-            if zeropower_backend != "identity":
-                g_diag = torch.diag_embed(g).contiguous()
-                result_diag = _lmo_for_2d_tensor(g_diag)
-                g = result_diag.diagonal().contiguous()
-            else:
-                g = _lmo_for_2d_tensor(g)
-
-            # TODO(JSC): JUST HARD CODE IT TO USE 'identity' backend and 'bias_rms' norm_factor for
-            # now until we add regex to extra the norm's weights
-            # zeropower_backend = "identity"
-            # norm_factor = "bias_rms"
-            # g = _lmo_for_2d_tensor(g)
-
-        else:
-            raise ValueError(f"Unknown grad shape: {g.shape}")
-
-        return g
-
-    @torch.no_grad()
-    def normalise_grad(self, g, norm_factor, eps):
-        if norm_factor == "spectral":
-            g = g * (g.size(0) / g.size(1)) ** 0.5
-        elif norm_factor == "image_spectral":
-            g = g * max((g.size(0) / g.size(1)) ** 0.5, 1)
-        elif norm_factor.startswith("embed"):
-            # NB: here assume shape [vocab_size, embed_dim]
-            rms_values = torch.sqrt(g.pow(2).sum(axis=1, keepdim=True))
-            g = g / (rms_values + eps)
-            if norm_factor == "embed_linear":
-                g = g * g.size(1)
-            elif norm_factor == "embed_sqrt":
-                g = g * g.size(1) ** 0.5
-            else:
-                raise ValueError(f"Unknown norm_factor: {norm_factor}")
-        elif norm_factor.startswith("unembed"):
-            rms_values = torch.sqrt(g.pow(2).sum(axis=1, keepdim=True))
-            g = g / (rms_values + eps)
-            if norm_factor == "unembed_linear":
-                g = g / g.size(1)
-            elif norm_factor == "unembed_sqrt":
-                g = g / g.size(1) ** 0.5
-            else:
-                raise ValueError(f"Unknown norm_factor: {norm_factor}")
-        elif norm_factor == "sign":
-            g = torch.sign(g)
-        elif norm_factor == "bias_rms":
-            rms_value = torch.sqrt(g.pow(2).mean())
-            g = g / (rms_value + eps)
-        elif norm_factor == "none":
-            pass
-        else:
-            raise ValueError(f"Unknown norm_factor: {norm_factor}")
-
-        return g
-
-    def __getstate__(self):
-        self._store_grads_in_state()
-        return super().__getstate__()
-
-    def __setstate__(self, state):
-        super().__setstate__(state)
-        self._load_grads_from_state()
-
-    def _store_grads_in_state(self):
-        for group in self.param_groups:
-            for param in group["params"]:
-                if isinstance(param, torch.Tensor) and param.grad is not None:
-                    self.state.setdefault(param, {})["grad_state"] = param.grad
-
-    def _load_grads_from_state(self):
-        for param, state in self.state.items():
-            if "grad_state" in state:
-                param.grad = state["grad_state"]
-            elif isinstance(param, torch.Tensor):
-                param.grad = None
-
-    def update_bucket_params(self, params, updates, start_idx, end_idx, tp_group=None):
-        # TODO(JSC): we could maybe use tesnor update rather than for-loop here
-        # can be helpful for FSDP and EP params
-        for idx_in_bucket in range(start_idx, end_idx):
-            shift = idx_in_bucket - start_idx
-            p = params[idx_in_bucket]
-            u = updates[shift]
-            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
-                self.parameters_to_groups[id(p)]
-            ]
-
-            if wd != 0:
-                # p.data.mul_(1 - wd*lr)
-                p.mul_(1 - wd * lr)
-
-            if isinstance(p, DTensor) and self.tp_enabled:
-                original_placements = p.placements
-                tp_mesh_dim = tp_axis(original_placements, p.shape == u.shape)
-
-            if isinstance(p, DTensor):
-                if tp_group is None or tp_mesh_dim is None:
-                    p.to_local().add_(u, alpha=-lr)
-                else:
-                    tp_rank = tp_group.rank()
-                    tp_sharded_dim = original_placements[tp_mesh_dim].dim
-                    chunk_size = p.to_local().shape[tp_sharded_dim]
-                    start_offset = tp_rank * chunk_size
-
-                    slicer = [slice(None)] * u.dim()
-                    slicer[tp_sharded_dim] = slice(
-                        start_offset, start_offset + chunk_size
-                    )
-                    u_sliced = u[slicer]
-                    p.to_local().add_(u_sliced, alpha=-lr)
-            else:
-                p.add_(u, alpha=-lr)
-
-            if momentum != 1 and self.is_light and p.grad is not None:
-                p.grad.mul_(1 - momentum)
-
+    @record_function("disco.step_scalar")
+    @torch.compile()
     def step_scalar(
         self,
         scalar_params,
@@ -483,145 +401,145 @@ class DistributedScion(torch.optim.Optimizer):
         skip_update=False,
         apply_on_weight=True,
     ):
-        if len(scalar_params) == 0:
-            return {}
+        """
+        We hardcode the update for scalar parameters to be the `sign` of the gradient.
+        """
+        if not scalar_params:
+            return
 
-        need_to_calculate_norm = self.need_to_calculate_norm
+        updates = []
+        for p in scalar_params:
+            _, nesterov, momentum, _, _ = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(p, momentum, nesterov)
+
+            if g is None:
+                updates.append(None)
+                continue
+
+            g_local = g.to_local() if isinstance(g, DTensor) else g
+            u = torch.sign(g_local)
+            updates.append(u)
+
+        if not skip_update:
+            # Scalar parameters are not TP-sharded, so tp_group is None.
+            self.update_bucket_params(
+                scalar_params, updates, 0, len(scalar_params), tp_group=None
+            )
+
+        if not self.need_to_calculate_norm:
+            return
 
         final_norms = {}
-        apply_on_weight = apply_on_weight and need_to_calculate_norm
-
-        for param_idx in range(len(scalar_params)):
-            p = scalar_params[param_idx]
-            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
-                self.parameters_to_groups[id(p)]
-            ]
-            g = self.get_momentum_or_grad(
-                p, momentum, nesterov, update_buffer=True, gather_to_local=False
-            )
-            g = g.to_local() if isinstance(g, DTensor) else g
-
-            # the lmo of scalar is just sign
-            u = torch.sign(g)
-
-            if not skip_update:
-                self.update_bucket_params([p], [u], 0, 1)
-
-            if need_to_calculate_norm:
+        if apply_on_weight and self.need_to_calculate_norm:
+            for i, p in enumerate(scalar_params):
+                p_local = p.to_local() if isinstance(p, DTensor) else p
                 cleaned_p_name = remove_orig_mod_and_weight_for_p_name(
-                    scalar_param_names[param_idx]
+                    scalar_param_names[i]
                 )
-                p = p.to_local() if isinstance(p, DTensor) else p
-                # final_norms[f"scalar_update_supremum/{cleaned_p_name}"] = -lr * u
-                # seems no need to log the update norm ? its always equals to LR
-                final_norms[f"scalar_param_supremum/{cleaned_p_name}"] = p.abs()
+                # The original code only logs the parameter's absolute value, as the
+                # update norm is constant (learning_rate * 1.0).
+                final_norms[f"scalar_param_supremum/{cleaned_p_name}"] = p_local.abs()
 
-        self.norms_at_current_step.update(final_norms)
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
 
+    @record_function("disco.step_embedding")
     def step_embedding(
-        self,
-        embed_params,
-        embed_param_names,
-        skip_update=False,
-        apply_on_weight=True,
+        self, embed_params, embed_param_names, skip_update=False, apply_on_weight=True
     ):
         if len(embed_params) == 0:
-            return {}
+            return
 
-        need_to_calculate_norm = self.need_to_calculate_norm
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
 
-        tp_group = None
-        # if self.dp_replicate_enabled:
-        #     dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
-        # else:
-        #     dp_replicate_group = None
-
-        if self.tp_enabled:
-            tp_group = self.world_mesh["tp"].get_group()
-
-        norms_of_update, norms_of_weight, final_norms = [], [], {}
-        apply_on_weight = apply_on_weight and need_to_calculate_norm
-
-        for param_idx in range(len(embed_params)):
-            p = embed_params[param_idx]
-            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+        # --- Phase 1: Parameter Update (Efficient, on shards) ---
+        # This part of your refactor is efficient and correct for the update.
+        # It computes updates on shards and applies them locally.
+        effective_grads = []
+        for p in embed_params:
+            _, nesterov, momentum, _, _ = self.groups_info[
                 self.parameters_to_groups[id(p)]
             ]
-            g = self.get_momentum_or_grad(
-                p, momentum, nesterov, update_buffer=True, gather_to_local=False
+            # Get gradient without gathering for efficiency
+            g = self.get_momentum_or_grad(p, momentum, nesterov, gather_to_local=False)
+
+            if not self.fsdp_enabled and self.tp_enabled:
+                # here is an edge case where [e.g. GPUS=TP, or GPUS=PP x TP]
+                # model weight is sharded, but gradient is Replicate
+                original_placements = p.placements
+                tp_mesh_dim = tp_axis(original_placements, True)
+                tp_sharded_dim = original_placements[tp_mesh_dim].dim
+                chunk_size = p.to_local().shape[tp_sharded_dim]
+                start_offset = tp_group.rank() * chunk_size
+                slicer = [slice(None)] * g.dim()
+                slicer[tp_sharded_dim] = slice(start_offset, start_offset + chunk_size)
+                g = g[tuple(slicer)]
+
+            effective_grads.append(g)
+
+        # LMO bucketed by param_kwargs
+        lmo_buckets = defaultdict(lambda: {"grads": [], "indices": []})
+        for i, g in enumerate(effective_grads):
+            if g is not None:
+                p = embed_params[i]
+                *_, param_kwargs = self.groups_info[self.parameters_to_groups[id(p)]]
+                kwargs_key = tuple(sorted(param_kwargs.items()))
+                lmo_buckets[kwargs_key]["grads"].append(g)
+                lmo_buckets[kwargs_key]["indices"].append(i)
+
+        updates = [None] * len(embed_params)
+        for kwargs_key, data in lmo_buckets.items():
+            param_kwargs = dict(kwargs_key)
+            for j, g in enumerate(data["grads"]):
+                updates[data["indices"][j]] = self.lmo(g, **param_kwargs)
+
+        if not skip_update:
+            self.update_bucket_params(
+                embed_params, updates, 0, len(embed_params), tp_group=None
             )
 
-            u = self.lmo(g, **param_kwargs)
+        # --- Phase 2: Norm Calculation (On Full Tensors for Correctness) ---
+        if not self.need_to_calculate_norm:
+            return
+        final_norms = {}
+        apply_on_weight = apply_on_weight and self.need_to_calculate_norm
 
-            #########################################################
-            # # As of we use norm for Embedding, maybe we should not do Reduce here
-            # if (
-            #     dp_replicate_group is not None
-            #     and self.extra_reduce_for_HSDP
-            #     and self.fsdp_enabled
-            # ):
-            #     dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
-            #     dist.barrier(group=dp_replicate_group)
-            if not skip_update:
-                self.update_bucket_params([p], [u], 0, 1, tp_group=tp_group)
-
-        if not need_to_calculate_norm:
-            return {}
-
-        # for the embedding, if we want to calculate the norm, we need to gather the gradient
-        for param_idx in range(len(embed_params)):
-            p, p_name = embed_params[param_idx], embed_param_names[param_idx]
-            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+        for i, (p, p_name) in enumerate(zip(embed_params, embed_param_names)):
+            lr, nesterov, momentum, _, param_kwargs = self.groups_info[
                 self.parameters_to_groups[id(p)]
             ]
-            # this is important, *Do NOT* update buffer twice here
-            g = self.get_momentum_or_grad(
-                p, momentum, nesterov, update_buffer=False, gather_to_local=True
-            )
-            """
-            TODO(JSC): maybe we can improve this [?]
-            Rather than Gather - LMO, we can do LMO - Gather such that we can avoid compute
-            lmo twice [?]. though lmo of embedding is not expensive
-            [kind of fixed], we dont do gather here anymore
-            """
+
+            # Gathering Gradient to a full tensor for norm calculation
+            g = self.get_momentum_or_grad(p, momentum, nesterov, gather_to_local=True)
             u = self.lmo(g, **param_kwargs)
 
+            # Calculate norms on the full tensors
+            need_T = CONST_NAME_OF_EMBEDDING in p_name
+            upd_norms = calculate_norm(-lr * u, self.norms_to_log, transpose=need_T)
+
+            # Gather the parameter itself to a full tensor if needed
             if apply_on_weight and isinstance(p, DTensor):
                 p = p.full_tensor()
 
-            norm_need_transpose = "tok_embeddings" in p_name
-            norms_of_update = calculate_norm(
-                -lr * u, self.norms_to_log, transpose=norm_need_transpose
-            )
             if apply_on_weight:
-                norms_of_weight: dict = calculate_norm(
-                    p, self.norms_to_log, transpose=norm_need_transpose
-                )
-            else:
-                norms_of_weight = None
+                wnorm = calculate_norm(p, self.norms_to_log, transpose=need_T)
 
-            # This should _not_ be an f-string since the variable names
-            # will be interpolated later.
-            embed_norm_key_template = "track_{task_name}_{norm_name}/{cleaned_p_name}"
             cleaned_p_name = remove_orig_mod_and_weight_for_p_name(p_name)
             for norm_name in self.norms_to_log:
-                final_norms[
-                    embed_norm_key_template.format(
-                        task_name="update",
-                        norm_name=norm_name,
-                        cleaned_p_name=cleaned_p_name,
-                    )
-                ] = norms_of_update[norm_name]
+                final_norms[f"track_update_{norm_name}/{cleaned_p_name}"] = upd_norms[
+                    norm_name
+                ]
                 if apply_on_weight:
-                    final_norms[
-                        embed_norm_key_template.format(
-                            task_name="param",
-                            norm_name=norm_name,
-                            cleaned_p_name=cleaned_p_name,
-                        )
-                    ] = norms_of_weight[norm_name]
-        self.norms_at_current_step.update(final_norms)
+                    final_norms[f"track_param_{norm_name}/{cleaned_p_name}"] = wnorm[
+                        norm_name
+                    ]
 
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_experts")
     def step_experts(
         self,
         expert_params,
@@ -630,7 +548,7 @@ class DistributedScion(torch.optim.Optimizer):
         apply_on_weight=True,
     ):
         if len(expert_params) == 0:
-            return {}
+            return
 
         need_to_calculate_norm = self.need_to_calculate_norm
 
@@ -659,10 +577,8 @@ class DistributedScion(torch.optim.Optimizer):
             lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
                 self.parameters_to_groups[id(p)]
             ]
-            g = self.get_momentum_or_grad(
-                p, momentum, nesterov, update_buffer=True, gather_to_local=False
-            )
-            u = self.lmo(g, **param_kwargs)
+            g = self.get_momentum_or_grad(p, momentum, nesterov)
+            u = self.lmo(g, **param_kwargs, transpose_experts=transpose)
 
             if not skip_update:
                 self.update_bucket_params([p], [u], 0, 1)
@@ -747,479 +663,507 @@ class DistributedScion(torch.optim.Optimizer):
                         )
                         final_norms[key_param] = gathered_weight_norms[idx]
 
-        self.norms_at_current_step.update(final_norms)
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
 
+    @record_function("disco.step_ddp")
     def step_ddp(
         self,
         ddp_params,
         ddp_param_names,
-        skip_update=False,
-        apply_on_weight=True,
+        skip_update: bool = False,
+        apply_on_weight: bool = True,
     ):
-        # Either we do DDP
-        # or we do TP,  there is no [DDP + TP] case but for safety we add sevel checks
-        # if len(ddp_params) == 0:
-        #     return {}
+        if len(ddp_params) == 0:
+            return
 
         need_to_calculate_norm = self.need_to_calculate_norm
-
-        tp_group, dp_replicate_group = None, None
-
-        rank = 0
-        bucket_size = world_size = 1
-        total_buckets = len(ddp_params)
-
-        if self.dp_replicate_enabled:
-            dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
-            world_size = dp_replicate_group.size()
-            rank = dp_replicate_group.rank()
-
-            bucket_size = world_size
-            total_buckets = math.ceil(len(ddp_params) / bucket_size)
-
-        if self.tp_enabled:
-            tp_group = self.world_mesh["tp"].get_group()
-            tp_world_size = dist.get_world_size(group=tp_group)
-
-        device = ddp_params[0].device if len(ddp_params) > 0 else torch.device("cuda")
-        cast_dtype = self.communication_dtype
-        zero_tensor = partial(torch.zeros, dtype=cast_dtype, device=device)
-
-        norms_of_update, norms_of_weight, final_norms = [], [], {}
-        padding_norms = {
-            norm_name: torch.tensor(0.0, device=device)
-            for norm_name in self.norms_to_log
-        }
         apply_on_weight = apply_on_weight and need_to_calculate_norm
 
-        # for DDP, we need to first update the buffer
-        for param_idx in range(len(ddp_params)):
-            p = ddp_params[param_idx]
-            _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+        # --- distributed groups ---
+        dp_group = (
+            self.world_mesh["dp_replicate"].get_group()
+            if self.dp_replicate_enabled
+            else None
+        )  # DDP group accessor
+        world_size = dp_group.size() if dp_group is not None else 1
+        rank = dp_group.rank() if dp_group is not None else 0
+
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+        tp_world_size = (
+            dist.get_world_size(group=tp_group) if tp_group is not None else 1
+        )
+
+        device = ddp_params[0].device
+        cast_dtype = self.communication_dtype  # comm/exchange dtype
+
+        # one DDP bucket spans `world_size` params
+        bucket_size = world_size
+        total_buckets = (
+            math.ceil(len(ddp_params) / bucket_size)
+            if world_size > 1
+            else len(ddp_params)
+        )
+
+        # --- Initializations for norm calculation ---
+        norms_of_update, norms_of_weight, final_norms = [], [], {}
+
+        # -------- Phase A: precompute local LMO updates (no comm) --------
+        local_updates: dict[int, torch.Tensor] = {}
+        local_indices = range(rank, len(ddp_params), world_size)
+        for i in local_indices:
+            p = ddp_params[i]
+            _, nesterov, momentum, _, param_kwargs = self.groups_info[
                 self.parameters_to_groups[id(p)]
             ]
-            g = self.get_momentum_or_grad(
-                p, momentum, nesterov, update_buffer=True, gather_to_local=False
-            )
+            g = self.get_momentum_or_grad(p, momentum, nesterov)  # relies on pre-pass
+            if isinstance(g, DTensor) and tp_group is not None:
+                g = gather_tp_shard(
+                    g.to_local(), tp_group, tp_world_size, g.placements
+                )  # TP tolerant
+            else:
+                g = g.to_local() if isinstance(g, DTensor) else g
+            u = self.lmo(g.to(dtype=cast_dtype), **param_kwargs)
+            local_updates[i] = u
 
-        #  then we do scion stuff
+        # -------- Phase B: DDP communication (per bucket) and build a global update cache --------
+        global_updates: list[torch.Tensor | None] = [None] * len(ddp_params)
+
         for bucket_idx in range(total_buckets):
             start_idx = bucket_idx * bucket_size
             end_idx = min(start_idx + bucket_size, len(ddp_params))
-            current_rank_idx = start_idx + rank
-            if current_rank_idx < len(ddp_params):
-                p = ddp_params[current_rank_idx]
-                # Step 1: Get the gradient
-                _, nesterov, momentum, wd, param_kwargs = self.groups_info[
-                    self.parameters_to_groups[id(p)]
-                ]
-                g = self.get_momentum_or_grad(
-                    p, momentum, nesterov, update_buffer=False, gather_to_local=False
-                )
-                if isinstance(g, DTensor) and self.tp_enabled:
-                    g = gather_tp_shard(
-                        g.to_local(), tp_group, tp_world_size, g.placements
-                    ).to(dtype=cast_dtype)
+            my_idx = start_idx + rank
 
+            if my_idx < end_idx:
+                send_u = local_updates[my_idx]
             else:
-                # To avoid idle stream, we pad the last rank
-                p = ddp_params[end_idx - 1]
-                g = zero_tensor(p.shape)
-                _, nesterov, momentum, wd, param_kwargs = self.groups_info[
-                    self.parameters_to_groups[id(p)]
-                ]
+                ref = ddp_params[end_idx - 1]
+                send_u = torch.zeros(ref.shape, dtype=cast_dtype, device=device)
 
-            # step 2: lmo
-            u = self.lmo(g, **param_kwargs)
-
-            if not skip_update:
-                # Step 3: FOR DDP, we do all-gather
-                if self.dp_replicate_enabled:
-                    # only gather params when we doing DDP + BUCKET
-                    gather_lists = [None] * world_size
-                    for i in range(world_size):
-                        param_idx = start_idx + i
-                        if i == rank or param_idx >= len(ddp_params):
-                            gather_lists[i] = u.to(dtype=cast_dtype)
-                        elif param_idx < len(ddp_params):
-                            p = ddp_params[start_idx + i]
-                            gather_lists[i] = zero_tensor(p.shape)
-                    dist.all_gather(
-                        gather_lists, u.to(dtype=cast_dtype), group=dp_replicate_group
-                    )
-                    if self.tp_enabled:
-                        # only if DP+TP we need to barrier here other-wise its automatically synced
-                        dist.barrier(group=dp_replicate_group)
-                else:
-                    # other wise (TP only), dp world_size is 1
-                    gather_lists = [u.to(dtype=cast_dtype)]
-
-                # Step 4: Update the parameters
-                self.update_bucket_params(
-                    ddp_params, gather_lists, start_idx, end_idx, tp_group=tp_group
-                )
-
-            if need_to_calculate_norm:
-                # so here, we already have update of each rank
-                p = ddp_params[min(current_rank_idx, len(ddp_params) - 1)]
-                lr, *_ = self.groups_info[self.parameters_to_groups[id(p)]]
-
-                if current_rank_idx < end_idx:
-                    norms_of_update.extend(
-                        calculate_norm(-lr * u, self.norms_to_log).values()
-                    )
-                else:
-                    norms_of_update.extend(padding_norms.values())
-                if apply_on_weight:
-                    if current_rank_idx < end_idx:
-                        if isinstance(p, DTensor) and self.tp_enabled:
-                            p = gather_tp_shard(
-                                p.to_local(), tp_group, tp_world_size, p.placements
-                            ).to(dtype=cast_dtype)
-
-                        norms_of_weight.extend(
-                            calculate_norm(p, self.norms_to_log).values()
-                        )
-                    else:
-                        norms_of_weight.extend(padding_norms.values())
-
-        if need_to_calculate_norm and len(norms_of_update) > 0:
-
-            norms_tensor = torch.stack(norms_of_update).to(device=device).float()
-            if self.dp_replicate_enabled:
-                gathered_update_norms = torch.empty(
-                    world_size * norms_tensor.shape[0],
-                    dtype=norms_tensor.dtype,
-                    device=norms_tensor.device,
-                )
-                dist.barrier(group=dp_replicate_group)
-                dist.all_gather_into_tensor(gathered_update_norms, norms_tensor)
-            else:
-                gathered_update_norms = norms_tensor
-
-            if apply_on_weight:
-                norms_tensor = torch.stack(norms_of_weight).to(device=device).float()
-                if self.dp_replicate_enabled:
-                    gathered_weight_norms = torch.empty(
-                        world_size * norms_tensor.shape[0],
-                        dtype=norms_tensor.dtype,
-                        device=norms_tensor.device,
-                    )
-                    dist.barrier(group=dp_replicate_group)
-                    dist.all_gather_into_tensor(gathered_weight_norms, norms_tensor)
-                else:
-                    gathered_weight_norms = norms_tensor
-
-            if rank == 0:
-                # This should _not_ be an f-string since the variable
-                # names will be interpolated later.
-                ddp_norm_key_template = "track_{task_name}_{norm_name}/{cleaned_p_name}"
-                num_norm_types = len(self.norms_to_log)
-                # total_buckets is already defined
-
-                for param_idx, p_name in enumerate(ddp_param_names):
-                    cleaned_p_name = remove_orig_mod_and_weight_for_p_name(p_name)
-
-                    # Determine which rank and bucket handled this parameter
-                    param_rank = param_idx % world_size
-                    param_bucket = param_idx // world_size
-
-                    for norm_idx, norm_name in enumerate(self.norms_to_log):
-                        # Calculate the correct index in the gathered tensor
-                        base_idx = (
-                            param_rank * total_buckets + param_bucket
-                        ) * num_norm_types
-                        norm_value_idx = base_idx + norm_idx
-
-                        final_norms[
-                            ddp_norm_key_template.format(
-                                task_name="update",
-                                norm_name=norm_name,
-                                cleaned_p_name=cleaned_p_name,
+            if dp_group is not None and world_size > 1 and not skip_update:
+                gathered = []
+                pad_buffer = None
+                for i in range(world_size):
+                    param_idx = start_idx + i
+                    if param_idx < len(ddp_params):
+                        ref = ddp_params[param_idx]
+                        if global_updates[param_idx] is None:
+                            global_updates[param_idx] = torch.empty(
+                                ref.shape, dtype=cast_dtype, device=device
                             )
-                        ] = gathered_update_norms[norm_value_idx]
+                        recv = global_updates[param_idx]
+                    else:
+                        ref = ddp_params[end_idx - 1]
+                        if pad_buffer is None or pad_buffer.shape != ref.shape:
+                            pad_buffer = torch.empty(
+                                ref.shape, dtype=cast_dtype, device=device
+                            )
+                        recv = pad_buffer
+                    gathered.append(recv)
+                dist.all_gather(gathered, send_u, group=dp_group)
+            else:
+                gathered = [send_u] if not skip_update else []
+            if not skip_update:
+                for i in range(end_idx - start_idx):
+                    global_updates[start_idx + i] = gathered[i]
 
-                        if apply_on_weight:
-                            final_norms[
-                                ddp_norm_key_template.format(
-                                    task_name="param",
-                                    norm_name=norm_name,
-                                    cleaned_p_name=cleaned_p_name,
-                                )
-                            ] = gathered_weight_norms[norm_value_idx]
-            dist.barrier()
+            # ---- local norms (on our owned slot only) ----
+            if need_to_calculate_norm:
+                if my_idx < end_idx:
+                    p = ddp_params[my_idx]
+                    lr, *_ = self.groups_info[self.parameters_to_groups[id(p)]]
+                    upd_norms = calculate_norm(
+                        -lr * local_updates[my_idx], self.norms_to_log
+                    )
+                else:
+                    upd_norms = {
+                        k: torch.tensor(0.0, device=device) for k in self.norms_to_log
+                    }
+                for v in upd_norms.values():
+                    norms_of_update.append(v)
 
-        self.norms_at_current_step.update(final_norms)
+        # -------- Phase C: apply once (vectorised foreach inside update_bucket_params) --------
+        if not skip_update:
+            self.update_bucket_params(
+                ddp_params, global_updates, 0, len(ddp_params), tp_group=tp_group
+            )
 
-    def step_fsdp(
+        # -------- Phase C.5: Calculate Weight Norms (POST-UPDATE) --------
+        if apply_on_weight:
+            for bucket_idx in range(total_buckets):
+                my_idx = bucket_idx * world_size + rank
+                if my_idx < len(ddp_params):
+                    w = ddp_params[my_idx]
+                    if isinstance(w, DTensor) and tp_group is not None:
+                        w = gather_tp_shard(
+                            w.to_local(), tp_group, tp_world_size, w.placements
+                        )
+                    w_norms = calculate_norm(w, self.norms_to_log)
+                else:
+                    w_norms = {
+                        k: torch.tensor(0.0, device=device) for k in self.norms_to_log
+                    }
+                for v in w_norms.values():
+                    norms_of_weight.append(v)
+
+        # -------- Phase D: final norm gather/log --------
+        if not need_to_calculate_norm:
+            return
+
+        upd = torch.stack(norms_of_update).float().to(device)
+        if dp_group is not None and world_size > 1:
+            gathered_upd = torch.empty(
+                world_size * upd.shape[0], dtype=upd.dtype, device=device
+            )
+            dist.all_gather_into_tensor(gathered_upd, upd, group=dp_group)
+        else:
+            gathered_upd = upd
+
+        if apply_on_weight:
+            w = torch.stack(norms_of_weight).float().to(device)
+            if dp_group is not None and world_size > 1:
+                gathered_w = torch.empty(
+                    world_size * w.shape[0], dtype=w.dtype, device=device
+                )
+                dist.all_gather_into_tensor(gathered_w, w, group=dp_group)
+            else:
+                gathered_w = w
+        else:
+            gathered_w = None
+
+        if self.is_dp_rank_0:
+            num_norm_types = len(self.norms_to_log)
+            for param_idx, p_name in enumerate(ddp_param_names):
+                cleaned = remove_orig_mod_and_weight_for_p_name(p_name)
+                owner_rank = param_idx % world_size
+                owner_bucket = param_idx // world_size
+                base = (owner_rank * total_buckets + owner_bucket) * num_norm_types
+                for k, norm_name in enumerate(self.norms_to_log):
+                    idx = base + k
+                    final_norms[f"track_update_{norm_name}/{cleaned}"] = gathered_upd[
+                        idx
+                    ]
+                    if apply_on_weight:
+                        final_norms[f"track_param_{norm_name}/{cleaned}"] = gathered_w[
+                            idx
+                        ]
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    def _gather_and_log_fsdp_norms(
         self,
-        fsdp_params,
+        norms_of_update,
+        norms_of_weight,
+        fsdp_group,
+        rank,
+        device,
         fsdp_param_names,
-        skip_update=False,
-        apply_on_weight=True,
+        world_size,
+        total_buckets,
+        apply_on_weight,
     ):
-        if len(fsdp_params) == 0:
-            return {}
+        """
+        Gathers FSDP norm tensors from all ranks and logs them on rank 0.
+        This is a collective operation followed by a rank-0 logging step.
+        """
+        # --- 1. Collective Communication: All ranks must participate ---
+        upd = torch.stack(norms_of_update).float().to(device)
+        gathered_update_norms = torch.empty(
+            world_size * upd.numel(), dtype=upd.dtype, device=device
+        )
+        dist.all_gather_into_tensor(gathered_update_norms, upd, group=fsdp_group)
+
+        gathered_weight_norms = None
+        if apply_on_weight and norms_of_weight:
+            w = torch.stack(norms_of_weight).float().to(device)
+            gathered_weight_norms = torch.empty(
+                world_size * w.numel(), dtype=w.dtype, device=device
+            )
+            dist.all_gather_into_tensor(gathered_weight_norms, w, group=fsdp_group)
+
+        # --- 2. Local Processing: Only rank 0 processes and logs the results ---
+        final_norms = {}
+        if self.is_dp_rank_0:
+            num_norm_types = len(self.norms_to_log)
+            entries_per_rank = total_buckets * num_norm_types
+            cleaned_names = [
+                remove_orig_mod_and_weight_for_p_name(pn) for pn in fsdp_param_names
+            ]
+
+            for param_idx, cleaned_p_name in enumerate(cleaned_names):
+                owner_rank = param_idx % world_size
+                bucket_idx_on_owner = param_idx // world_size
+                base = (
+                    owner_rank * entries_per_rank + bucket_idx_on_owner * num_norm_types
+                )
+
+                for norm_idx, norm_name in enumerate(self.norms_to_log):
+                    idx = base + norm_idx
+                    final_norms[f"track_update_{norm_name}/{cleaned_p_name}"] = (
+                        gathered_update_norms[idx]
+                    )
+                    if apply_on_weight and gathered_weight_norms is not None:
+                        final_norms[f"track_param_{norm_name}/{cleaned_p_name}"] = (
+                            gathered_weight_norms[idx]
+                        )
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_fsdp")
+    def step_fsdp(
+        self, fsdp_params, fsdp_param_names, skip_update=False, apply_on_weight=True
+    ):
+        if not fsdp_params:
+            return
+
+        # ---- Setup (as in your code) ----
         need_to_calculate_norm = self.need_to_calculate_norm
-        tp_group, dp_replicate_group = None, None
-        """
-        To make FSDP+DP works, we lets step_fsdp work on each dp_replicate separately.
-        Hence, we only care about the world size inside the dp_replicate.
-        """
-
-        # due to the werid implementation of parallel_dims.py (upstream)
-        # here we should use `dp_shard_cp` rather then `dp_shard` as of
-        # CP is also part of the dp_shard
-        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
-
-        if self.dp_replicate_enabled:
-            dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
-
-        if self.tp_enabled:
-            tp_group = self.world_mesh["tp"].get_group()
-            tp_world_size = dist.get_world_size(group=tp_group)
-
-        world_size = dist.get_world_size(fsdp_group)
-        rank = dist.get_rank(fsdp_group)
-
-        # @ THIS IS A HACK
-        bucket_size = world_size
-        total_buckets = math.ceil(len(fsdp_params) / bucket_size)
-
-        device = fsdp_params[0].device
-        cast_dtype = self.communication_dtype
-        zero_tensor = partial(torch.empty, dtype=cast_dtype, device=device)
-
-        norms_of_update, norms_of_weight, final_norms = [], [], {}
-
-        padding_norms = {
-            norm_name: torch.tensor(0.0, device=device)
-            for norm_name in self.norms_to_log
-        }
-
         apply_on_weight = apply_on_weight and need_to_calculate_norm
 
-        # Process each bucket
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+        world_size = dist.get_world_size(fsdp_group)
+        rank = dist.get_rank(fsdp_group)
+        device = fsdp_params[0].device
+        cast_dtype = self.communication_dtype
+
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+        tp_world_size = dist.get_world_size(group=tp_group) if tp_group else 1
+        dp_replicate_group = (
+            self.world_mesh["dp_replicate"].get_group()
+            if self.dp_replicate_enabled
+            else None
+        )
+
+        global_updates = [None] * len(fsdp_params)
+        norms_of_update, norms_of_weight = [], []
+        padding_norms = {k: torch.tensor(0.0, device=device) for k in self.norms_to_log}
+
+        # ---- Owner-per-bucket scheme (bucket size = world_size) ----
+        total_buckets = math.ceil(len(fsdp_params) / world_size)
+
         for bucket_idx in range(total_buckets):
-            start_idx = bucket_idx * bucket_size
-            end_idx = min(start_idx + bucket_size, len(fsdp_params))
+            start_idx = bucket_idx * world_size
+            end_idx = min(start_idx + world_size, len(fsdp_params))
 
-            # Step 1: Prepare data for first all_to_all
             grads_send_list, send_shapes = [], []
-            target_shape, param_kwargs = None, None
+            target_shape, param_kwargs_me = None, None
 
-            for rank_idx in range(world_size):
-                current_rank_idx = start_idx + rank_idx
-
-                if current_rank_idx < len(fsdp_params):
-                    p = fsdp_params[current_rank_idx]
-                    _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+            # Build per-destination payloads:
+            for i in range(world_size):
+                p_idx = start_idx + i
+                if p_idx < end_idx:
+                    p = fsdp_params[p_idx]
+                    _, nesterov, momentum, _, param_kwargs = self.groups_info[
                         self.parameters_to_groups[id(p)]
                     ]
-
                     g = self.get_momentum_or_grad(
-                        p,
-                        momentum,
-                        nesterov,
-                        update_buffer=True,
-                        gather_to_local=False,
-                    )
+                        p, momentum, nesterov
+                    )  # may be DTensor
 
-                    original_placements = g.placements
-                    tp_mesh_dim = tp_axis(original_placements)
-                    if tp_group is not None and tp_mesh_dim is not None:
-                        # the reason we need `tp_mesh_dim` is we want a flexible solution
-                        # that Attention go TP and MLP go EP
-                        g = gather_tp_shard(
-                            g.to_local(), tp_group, tp_world_size, original_placements
-                        ).to(dtype=cast_dtype)
-                    else:
-                        g = g.to_local().to(dtype=cast_dtype)
-
-                    # Save the shape info for this parameter
-                    if rank == rank_idx:
-                        target_shape = p.shape
-                else:
-                    # Use a dummy shape for parameters beyond our range
-                    p = fsdp_params[end_idx - 1]
-                    g = zero_tensor(p.to_local().shape)
-
-                grads_send_list.append(g)
-                send_shapes.append(g.shape)
-
-            # Make sure target_shape is initialized
-            # (trigger by the padding of the last ranks)
-            if target_shape is None and end_idx > 0:
-                target_shape = fsdp_params[end_idx - 1].shape
-                param_kwargs = self.groups_info[
-                    self.parameters_to_groups[id(fsdp_params[end_idx - 1])]
-                ][-1]
-
-            recv_shapes = [
-                calculate_shard_shape(target_shape, rank_idx, world_size)
-                for rank_idx in range(world_size)
-            ]
-            recv_list = [zero_tensor(shape) for shape in recv_shapes]
-            # Step 3: First all_to_all - using ASYNC version
-            dist.barrier()
-            dist.all_to_all(recv_list, grads_send_list, group=fsdp_group)
-            # Step 5: Concatenate received gradients along dimension 0 and perform NS5
-            # All tensors in recv_list should have the same dimensions except for dim 0
-
-            full_g = torch.cat(recv_list, dim=0)
-            u = self.lmo(full_g, **param_kwargs)
-            dist.barrier(group=fsdp_group)
-
-            if dp_replicate_group is not None and self.extra_reduce_for_HSDP:
-                dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
-                dist.barrier(group=dp_replicate_group)
-            # in case of FSDP+DP, we can do a All-Reduce here sync the grads
-            if not skip_update:
-                # Step 6: Split the processed tensor back for second all_to_all
-                split_sizes = [shape[0] for shape in recv_shapes]
-
-                grads_send_list = list(torch.split(u, split_sizes, dim=0))
-                recv_list = [zero_tensor(shape) for shape in send_shapes]
-                # Step 8: Second all_to_all - using ASYNC version
-                dist.all_to_all(recv_list, grads_send_list, group=fsdp_group)
-                del grads_send_list
-                # Step 10: Update parameters using the results
-                self.update_bucket_params(
-                    fsdp_params,
-                    recv_list,
-                    start_idx,
-                    end_idx,
-                    tp_group=tp_group,
-                )
-
-            if need_to_calculate_norm:
-                if start_idx + rank < end_idx:
-                    lr, *_ = self.groups_info[
-                        self.parameters_to_groups[id(fsdp_params[start_idx + rank])]
-                    ]
-                    norms = calculate_norm(-lr * u, self.norms_to_log)
-                else:
-                    norms = padding_norms
-                norms_of_update.extend(norms.values())
-
-                if apply_on_weight:
-                    params_send_list = []
-                    for rank_idx in range(world_size):
-                        current_rank_idx = start_idx + rank_idx
-                        if current_rank_idx < len(fsdp_params):
-                            p = fsdp_params[current_rank_idx]
-                        else:
-                            p = fsdp_params[end_idx - 1]
-
-                        # her is patch for FSDP+TP
-                        original_placements = p.placements
+                    if isinstance(g, DTensor):
+                        original_placements = g.placements
                         tp_mesh_dim = tp_axis(original_placements)
-                        if tp_group is not None and tp_mesh_dim is not None:
-                            p = gather_tp_shard(
-                                p.to_local(),
+                        if tp_group and tp_mesh_dim is not None:
+                            g_local = gather_tp_shard(
+                                g.to_local(),
                                 tp_group,
                                 tp_world_size,
                                 original_placements,
-                            ).to(dtype=cast_dtype)
+                            )
                         else:
-                            p = p.to_local().to(dtype=cast_dtype)
-
-                        params_send_list.append(p)
-
-                    recv_list = [zero_tensor(shape) for shape in recv_shapes]
-
-                    dist.barrier(group=fsdp_group)
-                    dist.all_to_all(recv_list, params_send_list, group=fsdp_group)
-
-                    full_weight = torch.cat(recv_list, dim=0)
-
-                    if start_idx + rank < end_idx:
-                        norms = calculate_norm(full_weight, self.norms_to_log)
+                            g_local = g.to_local()
                     else:
-                        norms = padding_norms
-                    norms_of_weight.extend(norms.values())
+                        g_local = g
 
-        # Below we need to all-gather the norms of update to rank-0
-        if need_to_calculate_norm and len(norms_of_update) > 0:
-            # Convert norms_of_update to a flat tensor for all-gather
-            # Each rank has bucket_size * len(self.norms_to_log) norm values
-            norms_tensor = torch.stack(norms_of_update).to(device=device).float()
-            gathered_update_norms = torch.empty(
-                world_size * norms_tensor.shape[0],
-                dtype=norms_tensor.dtype,
-                device=norms_tensor.device,
-            )
-            dist.barrier(group=fsdp_group)
-            dist.all_gather_into_tensor(
-                gathered_update_norms, norms_tensor, group=fsdp_group
-            )
+                    grads_send_list.append(g_local.to(dtype=cast_dtype))
+                    send_shapes.append(g_local.shape)
 
-            if apply_on_weight:
-                norms_tensor = torch.stack(norms_of_weight).to(device=device).float()
-                gathered_weight_norms = torch.empty(
-                    world_size * norms_tensor.shape[0],
-                    dtype=norms_tensor.dtype,
-                    device=norms_tensor.device,
-                )
-                dist.barrier(group=fsdp_group)
-                dist.all_gather_into_tensor(
-                    gathered_weight_norms, norms_tensor, group=fsdp_group
-                )
+                    if i == rank:
+                        target_shape = p.shape
+                        param_kwargs_me = param_kwargs
+                else:
+                    # pad so that list length == world_size
+                    ref_p = fsdp_params[end_idx - 1]
+                    dummy = torch.zeros(
+                        ref_p.to_local().shape, dtype=cast_dtype, device=device
+                    )
+                    grads_send_list.append(dummy)
+                    send_shapes.append(dummy.shape)
 
-            if rank == 0:
-                # ----- only rank 0 reconstructs -----
-                num_norm_types = len(self.norms_to_log)
-                entries_per_rank = total_buckets * num_norm_types
+            # Pick a reference target if this rank owns none in this bucket
+            if target_shape is None:
+                ref_idx = end_idx - 1
+                target_shape = fsdp_params[ref_idx].shape
+                param_kwargs_me = self.groups_info[
+                    self.parameters_to_groups[id(fsdp_params[ref_idx])]
+                ][-1]
 
-                # pre-clean names once
-                cleaned_names = [
-                    remove_orig_mod_and_weight_for_p_name(pn) for pn in fsdp_param_names
+            # Receive slices (one from each source) that together make the full grad for the owned param
+            recv_shapes = [
+                calculate_shard_shape(target_shape, r, world_size)
+                for r in range(world_size)
+            ]
+            recv_list_grads = [
+                torch.empty(s, dtype=cast_dtype, device=device) for s in recv_shapes
+            ]
+
+            # A2A: shards -> owners
+            dist.all_to_all(
+                recv_list_grads, grads_send_list, group=fsdp_group
+            )  # list API
+
+            full_g = torch.cat(recv_list_grads, dim=0)
+            u = self.lmo(full_g, **param_kwargs_me)
+
+            if dp_replicate_group and self.extra_reduce_for_HSDP:
+                dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
+
+            if not skip_update:
+                # Split owner’s update by destination rows and scatter back
+                split_rows = [s[0] for s in recv_shapes]
+                updates_send_list = list(torch.split(u, split_rows, dim=0))
+                recv_list_updates = [
+                    torch.empty(s, dtype=cast_dtype, device=device) for s in send_shapes
                 ]
 
-                fsdp_norm_key_template = (
-                    "track_{task_name}_{norm_name}/{cleaned_p_name}"
+                # A2A: owners -> shards
+                dist.all_to_all(recv_list_updates, updates_send_list, group=fsdp_group)
+
+                # Materialise bucket’s updates into global list
+                for i in range(end_idx - start_idx):
+                    global_updates[start_idx + i] = recv_list_updates[i]
+
+            # optional logging of update norms
+            if need_to_calculate_norm:
+                my_param_in_bucket = (start_idx + rank) < end_idx
+                if my_param_in_bucket:
+                    p = fsdp_params[start_idx + rank]
+                    lr, *_ = self.groups_info[self.parameters_to_groups[id(p)]]
+                    upd_norms = calculate_norm(-lr * u, self.norms_to_log)
+                else:
+                    upd_norms = padding_norms
+                norms_of_update.extend(upd_norms.values())
+
+        # Single vectorised apply (as in your file)
+        if not skip_update:
+            self.update_bucket_params(
+                fsdp_params,
+                global_updates,
+                0,
+                len(fsdp_params),
+                tp_group=self.world_mesh["tp"].get_group() if self.tp_enabled else None,
+            )
+
+        # --- Calculate Weight Norms (POST-UPDATE) ---
+        if apply_on_weight:
+            for bucket_idx in range(total_buckets):
+                start_idx = bucket_idx * world_size
+                end_idx = min(start_idx + world_size, len(fsdp_params))
+                my_param_in_bucket = (start_idx + rank) < end_idx
+
+                # Determine target shape for reconstruction, even if this rank is padding
+                ref_p_idx = start_idx + rank if my_param_in_bucket else end_idx - 1
+                target_shape = fsdp_params[ref_p_idx].shape
+
+                params_send_list = []
+                for i in range(world_size):
+                    param_idx = start_idx + i
+                    p = fsdp_params[param_idx if param_idx < end_idx else end_idx - 1]
+
+                    original_placements = p.placements
+                    tp_mesh_dim = tp_axis(original_placements)
+                    if tp_group and tp_mesh_dim is not None:
+                        p_local = gather_tp_shard(
+                            p.to_local(), tp_group, tp_world_size, original_placements
+                        )
+                    else:
+                        p_local = p.to_local()
+                    params_send_list.append(p_local.to(dtype=cast_dtype))
+
+                recv_shapes = [
+                    calculate_shard_shape(target_shape, r, world_size)
+                    for r in range(world_size)
+                ]
+                recv_list_params = [
+                    torch.empty(s, dtype=cast_dtype, device=device) for s in recv_shapes
+                ]
+                dist.all_to_all(recv_list_params, params_send_list, group=fsdp_group)
+
+                full_weight = torch.cat(recv_list_params, dim=0)
+
+                w_norms = (
+                    calculate_norm(full_weight, self.norms_to_log)
+                    if my_param_in_bucket
+                    else padding_norms
                 )
+                norms_of_weight.extend(w_norms.values())
 
-                assert (
-                    gathered_update_norms.numel() == world_size * entries_per_rank
-                ), "update norms size mismatch"
-                if apply_on_weight:
-                    assert (
-                        gathered_weight_norms.numel() == world_size * entries_per_rank
-                    ), "weight norms size mismatch"
+        # --- Phase D: gather and log norms once ---
 
-                for param_idx, cleaned_p_name in enumerate(cleaned_names):
-                    r = param_idx % world_size  # rank that owned this param
-                    b = param_idx // world_size  # bucket index on that rank
-                    base = r * entries_per_rank + b * num_norm_types
+        if need_to_calculate_norm and norms_of_update:
+            self._gather_and_log_fsdp_norms(
+                norms_of_update,
+                norms_of_weight,
+                fsdp_group,
+                rank,
+                device,
+                fsdp_param_names,
+                world_size,
+                total_buckets,
+                apply_on_weight,
+            )
 
-                    for norm_idx, norm_name in enumerate(self.norms_to_log):
-                        idx = base + norm_idx
-                        # Index must exist thanks to padding
-                        final_norms[
-                            fsdp_norm_key_template.format(
-                                task_name="update",
-                                norm_name=norm_name,
-                                cleaned_p_name=cleaned_p_name,
-                            )
-                        ] = gathered_update_norms[idx]
+    @record_function("disco._prepare_gradients_and_momentum")
+    def prepare_gradients_and_momentum(self) -> None:
+        """
+        Fused pre-pass that updates momentum buffers for *all* parameters
+        with available grads:
+            buf <- (1 - m) * buf + m * g
+        It performs foreach-kernel updates per (device, dtype, momentum),
+        """
+        buckets = defaultdict(lambda: {"bufs": [], "grads": [], "m": 0.0})
 
-                        if apply_on_weight:
-                            final_norms[
-                                fsdp_norm_key_template.format(
-                                    task_name="param",
-                                    norm_name=norm_name,
-                                    cleaned_p_name=cleaned_p_name,
-                                )
-                            ] = gathered_weight_norms[idx]
+        for group in self.param_groups:
+            m = float(group["momentum"])
+            use_momentum = (not self.is_light) and (0.0 < m < 1.0)
 
-            dist.barrier(group=fsdp_group)
-        self.norms_at_current_step.update(final_norms)
+            if not use_momentum:
+                continue
 
-    @torch.no_grad()
-    def get_momentum_or_grad(
-        self, p, momentum, nesterov, update_buffer=False, gather_to_local=False
-    ):
+            for p in group["params"]:
+                g = getattr(p, "grad", None)
+                if g is None or not p.requires_grad:
+                    continue
+
+                # Initialize the momentum buffer if it's the first time.
+                state = self.state.setdefault(p, {})
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+
+                # Add the buffer and gradient to the appropriate bucket.
+                key = (g.dtype, m)
+                bucket = buckets[key]
+                bucket["bufs"].append(buf)
+                bucket["grads"].append(g)
+                bucket["m"] = m
+
+        # Launch the fused kernels for each bucket.
+        for (_, m), bucket_data in buckets.items():
+            if not bucket_data["bufs"]:
+                continue
+            # Perform the momentum update: buf = buf * (1 - m) + g * m
+            torch._foreach_mul_(bucket_data["bufs"], 1.0 - m)
+            torch._foreach_add_(bucket_data["bufs"], bucket_data["grads"], alpha=m)
+
+    @record_function("disco.get_momentum_or_grad")
+    def get_momentum_or_grad(self, p, momentum, nesterov, gather_to_local=False):
+        """
+        Retrieves the effective gradient for a parameter.
+        Assumes the momentum buffer has already been updated in a pre-pass.
+        """
         g = p.grad
         if g is None or not p.requires_grad:
             return None
@@ -1227,30 +1171,294 @@ class DistributedScion(torch.optim.Optimizer):
         use_momentum = momentum > 0 and momentum < 1
 
         if not self.is_light and use_momentum:
-            state = self.state[p]
-            if "momentum_buffer" not in state.keys():
-                if update_buffer:
-                    state["momentum_buffer"] = torch.zeros_like(g)
-                else:
-                    """
-                    When you using DDP + Dist-muon,you might trieer an error here.
-                    Because in the optimizer.log you try to log all gradient's norm.
-                    But for DDP + Dist-muon, each rank only has a part of the gradient.
-
-                    --
-                    For debug, you can return None here.
-                    """
-                    raise ValueError(
-                        "Momentum buffer not found in optimizer state. "
-                        "Please check if the optimizer is initialized correctly."
-                    )
+            state = self.state.get(p, None)
+            if state is None or "momentum_buffer" not in state:
+                raise ValueError(
+                    "Momentum buffer missing; ensure pre-pass ran before calling get_momentum_or_grad."
+                )
+            # The buffer is already updated, so we just retrieve it.
             buf = state["momentum_buffer"]
-            if update_buffer:
-                buf.mul_(1 - momentum).add_(g, alpha=momentum)
-            else:
-                buf = buf.mul(1 - momentum).add(g, alpha=momentum)
             g = buf if not nesterov else buf.mul(1 - momentum).add(g, alpha=momentum)
 
         if gather_to_local and isinstance(g, DTensor):
             g = g.redistribute(placements=[Replicate()] * g.device_mesh.ndim).to_local()
+
         return g
+
+    @record_function("disco.update_bucket_params")
+    def update_bucket_params(self, params, updates, start_idx, end_idx, tp_group=None):
+        slice_params = params[start_idx:end_idx]
+        slice_updates = updates[: (end_idx - start_idx)]
+        # already prepare a bucket of same length
+
+        prepared = []
+        if tp_group is not None:
+            tp_rank = tp_group.rank()
+            for p, u in zip(slice_params, slice_updates):
+                if u is None:
+                    prepared.append((p, None))
+                    continue
+                if isinstance(p, DTensor):
+                    p_local = p.to_local()
+                    placements = p.placements
+                    tp_mesh_dim = tp_axis(placements, tp_enabled=(u.shape == p.shape))
+                    if tp_mesh_dim is not None:
+                        shard_dim = placements[tp_mesh_dim].dim
+                        # Skip TP slicing if the update already matches the local shard.
+                        if u.shape != p_local.shape:
+                            chunk_size = p_local.shape[shard_dim]
+                            start = tp_rank * chunk_size
+                            slicer = [slice(None)] * u.dim()
+                            slicer[shard_dim] = slice(start, start + chunk_size)
+                            u = u[tuple(slicer)]
+                prepared.append((p, u))
+        else:
+            prepared = list(zip(slice_params, slice_updates))
+
+        # ------------- Phase 2: foreach buckets -------------
+        buckets = defaultdict(
+            lambda: {
+                "orig": [],
+                "locals": [],
+                "updates": [],
+                "lr": None,
+                "wd": None,
+                "m": None,
+            }
+        )
+
+        for p, u in prepared:
+            if u is None:
+                continue
+            lr, _, momentum, wd, _ = self.groups_info[self.parameters_to_groups[id(p)]]
+            p_local = p.to_local() if isinstance(p, DTensor) else p
+
+            # robust shape check after TP slicing; if it still fails, it’s a caller misalignment
+            if p_local.shape != u.shape:
+                raise ValueError(
+                    f"Shape mismatch between parameter shard {p_local.shape} and update slice {u.shape}. "
+                    f"Ensure you pass the same DDP/FSDP window and slice TP updates. "
+                )
+
+            # dtype/device consistency for foreach
+            if u.dtype is not p_local.dtype:
+                u = u.to(p_local.dtype)
+
+            key = (p_local.device, p_local.dtype, float(lr), float(wd), float(momentum))
+            b = buckets[key]
+            b["orig"].append(p)
+            b["locals"].append(p_local)
+            b["updates"].append(u)
+            b["lr"], b["wd"], b["m"] = lr, wd, momentum
+
+        for (_, _, lr, wd, m), data in buckets.items():
+            if not data["locals"]:
+                continue
+            if wd != 0.0:
+                torch._foreach_mul_(data["locals"], 1.0 - wd * lr)
+            torch._foreach_add_(data["locals"], data["updates"], alpha=-lr)
+
+            # light-mode grad decay retained for parity (won’t run; is_light is False in this optimizer)
+            if self.is_light and m != 1.0:
+                # group grads by device/dtype for foreach
+                gmap = defaultdict(list)
+                for p in data["orig"]:
+                    if p.grad is not None:
+                        g = p.grad.to_local() if isinstance(p.grad, DTensor) else p.grad
+                        gmap[(g.device, g.dtype)].append(g)
+                for _, gs in gmap.items():
+                    torch._foreach_mul_(gs, 1.0 - m)
+
+    @record_function("disco.step_fsdp_nvshmem_fixed")
+    def step_fsdp_nvshmem(
+        self,
+        fsdp_params,
+        fsdp_param_names,
+        skip_update: bool = False,
+        apply_on_weight: bool = True,
+    ):
+        if not fsdp_params:
+            return
+
+        # --- 1. SETUP ---
+        device = fsdp_params[0].device
+        torch.cuda.set_device(device)
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+        world_size, rank = fsdp_group.size(), fsdp_group.rank()
+        cast_dtype = self.communication_dtype
+        total_params = len(fsdp_params)
+
+        # Optional groups for TP/HSDP
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+        tp_world = dist.get_world_size(group=tp_group) if tp_group else 1
+        dp_rep_group = (
+            self.world_mesh["dp_replicate"].get_group()
+            if self.dp_replicate_enabled
+            else None
+        )
+
+        # Calculate workspace size
+        max_full_elems = max((p.numel() for p in fsdp_params), default=0)
+        if max_full_elems == 0:
+            return
+        padded_shard_elems = math.ceil(max_full_elems / world_size)
+
+        # Buffer layout: A single large window for all parameters.
+        # Each parameter `p_i` gets a block of `world_size * padded_shard_elems`.
+        # Within that block, rank `j` writes its shard for `p_i` at offset `j * padded_shard_elems`.
+        workspace_elems = total_params * world_size * padded_shard_elems
+
+        # --- NVSHMEM Workspace & Streams ---
+        import torch.distributed._symmetric_memory as symm_mem
+
+        symm_mem.set_backend("NVSHMEM")
+        symm_mem.enable_symm_mem_for_group(fsdp_group.group_name)
+
+        symm_buf = symm_mem.empty((workspace_elems,), dtype=cast_dtype, device=device)
+        hdl = symm_mem.rendezvous(symm_buf, fsdp_group)
+
+        # Simplified stream structure: one for I/O, N for compute
+        io_stream = torch.cuda.Stream()
+        num_compute_streams = int(
+            os.environ.get("DISCO_NVSHMEM_FSDP_COMPUTE_STREAMS", "2")
+        )
+        compute_streams = [torch.cuda.Stream() for _ in range(num_compute_streams)]
+
+        # --- Buffers & Events for Owner ---
+        owned_indices = [i for i in range(total_params) if (i % world_size) == rank]
+        owner_full_grads = {
+            i: torch.empty(fsdp_params[i].shape, dtype=cast_dtype, device=device)
+            for i in owned_indices
+        }
+        owner_updates = {
+            i: torch.empty(fsdp_params[i].shape, dtype=cast_dtype, device=device)
+            for i in owned_indices
+        }
+        grad_ready_events = {i: torch.cuda.Event() for i in owned_indices}
+        compute_done_events = {i: torch.cuda.Event() for i in owned_indices}
+        local_updates = [None] * total_params
+
+        # =================================================================
+        #  SEQUENTIAL EXECUTION: PUSH -> GATHER -> COMPUTE -> SCATTER -> READ
+        # =================================================================
+
+        # --- PHASE A: PUSH LOCAL GRADIENTS ---
+        # Each rank writes its local gradient shard into the owner's symmetric memory window.
+        # --- PHASE B: GATHER FULL GRADIENTS (Owner) & COMPUTE LMO ---
+        # This is now a two-step sequential process instead of an overlapped one.
+
+        # STEP B-1: Schedule all GATHER operations on the I/O stream.
+        with torch.cuda.stream(io_stream):
+            for i, p_idx in enumerate(owned_indices):
+                full_grad_tensor = owner_full_grads[p_idx]
+                current_offset = 0
+                for src_rank in range(world_size):
+                    shard_shape = calculate_shard_shape(
+                        full_grad_tensor.shape, src_rank, world_size
+                    )
+                    num_elems = math.prod(shard_shape)
+                    if num_elems == 0:
+                        continue
+
+                    offset = (p_idx * world_size + src_rank) * padded_shard_elems
+                    src_buffer = hdl.get_buffer(
+                        rank, (padded_shard_elems,), cast_dtype, storage_offset=offset
+                    )
+
+                    dest_view = (
+                        full_grad_tensor.narrow(0, current_offset, shard_shape[0])
+                        .contiguous()
+                        .flatten()
+                    )
+                    dest_view.copy_(src_buffer[:num_elems], non_blocking=True)
+                    current_offset += shard_shape[0]
+
+        # Synchronization Point: Wait for ALL GATHER operations on the I/O stream to complete.
+        io_stream.synchronize()
+
+        # STEP B-2: Now that all gradients are gathered, schedule all LMO computations.
+        for i, p_idx in enumerate(owned_indices):
+            compute_stream = compute_streams[i % num_compute_streams]
+            with torch.cuda.stream(compute_stream):
+                # No wait_event is needed here anymore, as the sync above guarantees data is ready.
+                p = fsdp_params[p_idx]
+                *_, param_kwargs = self.groups_info[self.parameters_to_groups[id(p)]]
+
+                update = self.lmo(owner_full_grads[p_idx], **param_kwargs)
+
+                if dp_rep_group and self.extra_reduce_for_HSDP:
+                    dist.all_reduce(update, group=dp_rep_group, op=dist.ReduceOp.AVG)
+
+                owner_updates[p_idx].copy_(update, non_blocking=True)
+                compute_done_events[p_idx].record(compute_stream)
+
+        # The next sync point remains the same
+        for stream in compute_streams:
+            stream.synchronize()
+        hdl.barrier(channel=200)
+
+        # --- PHASE C: SCATTER UPDATES ---
+        # Each owner scatters its computed update back to the respective ranks.
+        with torch.cuda.stream(io_stream):
+            for p_idx in owned_indices:
+                io_stream.wait_event(compute_done_events[p_idx])
+                update = owner_updates[p_idx]
+
+                current_offset = 0
+                for dest_rank in range(world_size):
+                    shard_shape = calculate_shard_shape(
+                        update.shape, dest_rank, world_size
+                    )
+                    num_elems = math.prod(shard_shape)
+
+                    update_shard = (
+                        update.narrow(0, current_offset, shard_shape[0])
+                        .contiguous()
+                        .flatten()
+                    )
+
+                    # Write the update shard into the destination rank's buffer
+                    # The slot is determined by the parameter index and *this rank's* ID (the owner).
+                    offset = (p_idx * world_size + rank) * padded_shard_elems
+                    peer_buffer = hdl.get_buffer(
+                        dest_rank,
+                        (padded_shard_elems,),
+                        cast_dtype,
+                        storage_offset=offset,
+                    )
+                    peer_buffer[:num_elems].copy_(update_shard, non_blocking=True)
+                    current_offset += shard_shape[0]
+
+        # Synchronization Point 3: Ensure all SCATTER operations are globally complete.
+        io_stream.synchronize()
+        hdl.barrier(channel=300)
+
+        # --- PHASE D: READ LOCAL UPDATES & APPLY ---
+        # Each rank reads its final update shard from its own symmetric memory.
+        with torch.cuda.stream(io_stream):
+            for p_idx, p in enumerate(fsdp_params):
+                owner_rank = p_idx % world_size
+                p_local = p.to_local() if isinstance(p, DTensor) else p
+
+                offset = (p_idx * world_size + owner_rank) * padded_shard_elems
+                src_buffer = hdl.get_buffer(
+                    rank, (padded_shard_elems,), cast_dtype, storage_offset=offset
+                )
+
+                update_buf = torch.empty_like(p_local, dtype=cast_dtype)
+                update_buf.flatten().copy_(
+                    src_buffer[: p_local.numel()], non_blocking=True
+                )
+                local_updates[p_idx] = update_buf
+
+        # Final Synchronization: ensure all reads are done before applying the update.
+        io_stream.synchronize()
+
+        if not skip_update:
+            self.update_bucket_params(
+                fsdp_params, local_updates, 0, total_params, tp_group=tp_group
+            )
+
+        # --- Cleanup ---
+        del hdl, symm_buf
+        torch.cuda.synchronize()

--- a/torchtitan/optimizers/naive_param_norm.py
+++ b/torchtitan/optimizers/naive_param_norm.py
@@ -20,7 +20,7 @@ import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate
 
-from torchtitan.optimizers.distributed_scion import DistributedScion
+from torchtitan.optimizers.distributed_scion import DiSCO
 from torchtitan.optimizers.norm_helper import calculate_norm
 from torchtitan.optimizers.scion import Scion
 
@@ -75,7 +75,7 @@ def gather_and_merge(local_stats: dict, dst: int = 0):
 
 
 def compute_grad(p, optimizer=None, **kwargs):
-    if isinstance(optimizer, (Scion, DistributedScion)):
+    if isinstance(optimizer, (Scion, DiSCO)):
         momentum = kwargs.pop("momentum")
         nesterov = kwargs.pop("nesterov")
         g = optimizer.get_momentum_or_grad(
@@ -137,7 +137,7 @@ def get_parameter_norms(model_parts, optimizers, norms_to_log):
         # NB: assumes correspondences between model parts and optimizers
         optimizer = optimizers[i]
         for group in optimizer.param_groups:
-            if isinstance(optimizer, (Scion, DistributedScion)):
+            if isinstance(optimizer, (Scion, DiSCO)):
                 param_kwargs = {
                     "momentum": group["momentum"],
                     "nesterov": group["nesterov"],

--- a/torchtitan/optimizers/norm_helper.py
+++ b/torchtitan/optimizers/norm_helper.py
@@ -41,7 +41,7 @@ def l1_to_rms_norm(W):
 
 
 @torch.no_grad()
-def rms_to_l1_norm(W):
+def rms_to_inf_norm(W):
     assert W.ndim == 2, "operator norm can only be applied to matrices"
     norm = torch.max(
         torch.linalg.norm(W.to(torch.float32), ord=2, dim=1, dtype=torch.float32)
@@ -96,7 +96,7 @@ def effective_rank(W):
 NORM_FUNCTIONS = {
     "rms_to_rms": rms_to_rms_norm,
     "l1_to_rms": l1_to_rms_norm,
-    "rms_to_l1": rms_to_l1_norm,
+    "rms_to_inf": rms_to_inf_norm,
     "supremum": supremum_norm,
     "condition_number": condition_number,
     "frobenius_norm": frobenius_norm,
@@ -106,8 +106,10 @@ NORM_FUNCTIONS = {
 }
 
 
+# here we use allow dynamic is to support the DDP running
 @torch.no_grad()
-@torch.compile(fullgraph=True)
+@torch.compile(dynamic=True)
+# @torch.compile(fullgraph=True)
 def fused_metrics(W, eps=1e-20):
     if W.ndim < 2:
         # Operator norms require a matrix.
@@ -125,7 +127,7 @@ def fused_metrics(W, eps=1e-20):
     col_l2 = colsqsum.sqrt()
 
     l1_to_rms = col_l2.max() / math.sqrt(fan_out)
-    rms_to_l1 = row_l2.max() * math.sqrt(fan_in)
+    rms_to_inf = row_l2.max() * math.sqrt(fan_in)
 
     S = torch.linalg.svdvals(Wf, driver="gesvd")
 
@@ -148,7 +150,7 @@ def fused_metrics(W, eps=1e-20):
     return {
         "rms_to_rms": spec,
         "l1_to_rms": l1_to_rms,
-        "rms_to_l1": rms_to_l1,
+        "rms_to_inf": rms_to_inf,
         "supremum": sup,
         "condition_number": cond,
         "frobenius_norm": frob_norm,
@@ -163,7 +165,7 @@ def get_norms_to_log(norms_to_log: str | list[str]) -> list[str]:
     Return a list of norms to log.
     The following contents in `norms_to_log` are special:
     - "default": replaced by
-                 ["rms_to_rms", "l1_to_rms", "rms_to_l1", "supremum", "condition_number"]
+                 ["rms_to_rms", "l1_to_rms", "rms_to_inf", "supremum", "condition_number"]
     - "all" or "everything": log all norms
     """
     if isinstance(norms_to_log, str):
@@ -182,7 +184,7 @@ def get_norms_to_log(norms_to_log: str | list[str]) -> list[str]:
             + [
                 "rms_to_rms",
                 "l1_to_rms",
-                "rms_to_l1",
+                "rms_to_inf",
                 "supremum",
                 "condition_number",
             ]

--- a/torchtitan/optimizers/utils.py
+++ b/torchtitan/optimizers/utils.py
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
+from typing import Any
+
+import torch
+
+from torchtitan.tools.logging import logger
 
 
 def remove_orig_mod_and_weight_for_p_name(name: str) -> str:
@@ -18,3 +23,177 @@ def remove_orig_mod_and_weight_for_p_name(name: str) -> str:
         r"\._checkpoint_wrapped_module", "", name
     )  # comes from activation checkpointing
     return name
+
+
+def create_disco_optimizer_kwargs_from_optimizer_config(
+    optimizer_config,
+    parallel_dims,
+) -> dict[str, Any]:
+    backend_steps = optimizer_config.backend_steps
+    zeropower_backend_algorithm = optimizer_config.zeropower_backend
+    momentum = optimizer_config.momentum
+    nesterov = optimizer_config.nesterov
+    is_light = optimizer_config.is_light
+    weight_decay = optimizer_config.weight_decay
+    lr = optimizer_config.lr
+    eps = optimizer_config.eps
+    norm_factor = optimizer_config.norm_factor
+
+    optimizer_kwargs = {
+        "parallel_dims": parallel_dims,
+        "is_light": is_light,
+        "weight_decay": weight_decay,
+        "lr": lr,
+        "momentum": momentum,
+        "nesterov": nesterov,
+        "eps": eps,
+        "norm_factor": norm_factor,
+        "backend": zeropower_backend_algorithm,
+        "backend_steps": backend_steps,
+    }
+
+    # Add extra_param_group_split_rules if present
+    if (
+        hasattr(optimizer_config, "extra_param_group_split_rules")
+        and optimizer_config.extra_param_group_split_rules
+    ):
+        optimizer_kwargs[
+            "extra_param_group_split_rules"
+        ] = optimizer_config.extra_param_group_split_rules
+
+    return optimizer_kwargs
+
+
+def create_disco_param_groups(
+    model: torch.nn.Module,
+    optimizer_kwargs: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """
+    Create and extract parameter groups for DiSCO optimizer.
+
+    This function combines parameter group configuration creation and parameter extraction:
+    1. Creates parameter group configurations from optimizer_kwargs
+    2. Extracts actual parameters from the model based on the configurations
+    3. Returns clean kwargs for the optimizer (without extra_param_group_split_rules)
+
+    This function supports a new parameter group configuration system where:
+    - Default values are taken from the top-level optimizer_kwargs
+    - Special parameter groups are defined in the 'extra_param_group_split_rules' list
+    - Each entry in extra_param_group_split_rules can override any default value
+
+    Example configuration:
+    ```python
+    optimizer_kwargs = {
+        "lr": 1e-3,
+        "weight_decay": 0.1,
+        "momentum": 0.9,
+        "norm_factor": "spectral",
+        "backend": "newtonschulz5",
+        "backend_steps": 5,
+        "extra_param_group_split_rules": [
+            {
+                "str_match": "embedding",
+                "lr": 1e-4,  # Override default lr
+                "norm_factor": "embed_sqrt"  # Override default norm_factor
+            },
+            {
+                "str_match": "router",
+                "lr": 5e-4,
+                "backend": "identity"  # Override default backend
+            }
+        ]
+    }
+    ```
+    Args:
+        model: The model to extract parameters from
+        optimizer_kwargs: Dictionary containing optimizer configuration
+
+    Returns:
+        Tuple of (parameter_groups, clean_kwargs) where:
+        - parameter_groups: List of parameter groups with actual parameters
+        - clean_kwargs: Clean kwargs for the optimizer (without extra_param_group_split_rules)
+    """
+    import functools
+    import re
+    from collections import OrderedDict
+
+    # Step 1: Create parameter group configurations
+    param_groups_config = []
+
+    # Get default configuration
+    default_config = {
+        "lr": optimizer_kwargs.get("lr"),
+        "weight_decay": optimizer_kwargs.get("weight_decay"),
+        "momentum": optimizer_kwargs.get("momentum"),
+        "nesterov": optimizer_kwargs.get("nesterov"),
+        "eps": optimizer_kwargs.get("eps"),
+        "norm_factor": optimizer_kwargs.get("norm_factor"),
+        "backend": optimizer_kwargs.get("backend"),
+        "backend_steps": optimizer_kwargs.get("backend_steps"),
+    }
+
+    # Process extra_param_group_split_rules if provided
+    extra_param_group_split_rules = optimizer_kwargs.get(
+        "extra_param_group_split_rules", []
+    )
+    for param_group in extra_param_group_split_rules:
+        # Start with default config and override with param_group specific values
+        group_config = default_config.copy()
+        group_config.update(param_group)
+
+        # Ensure str_match is present
+        if "str_match" not in group_config:
+            logger.warning(
+                "extra_param_group_split_rules entry missing 'str_match', skipping"
+            )
+            continue
+
+        # Rename str_match to param_str_match for compatibility
+        group_config["param_str_match"] = group_config.pop("str_match")
+
+        param_groups_config.append(group_config)
+
+    # Step 2: Extract actual parameters from the model
+    param_dict = OrderedDict(
+        (n, p) for n, p in model.named_parameters() if p.requires_grad
+    )
+    params = []
+
+    for param_group_config in param_groups_config:
+        # Make a copy to avoid modifying the original
+        group_config = param_group_config.copy()
+        str_match = group_config.pop("param_str_match")
+        filter_fn = functools.partial(re.search, str_match)
+        param_names = [n for n in param_dict.keys() if filter_fn(n)]
+
+        group_params = {
+            "params": [param_dict.pop(n) for n in param_names],
+            "param_names": param_names,
+        }
+        assert len(group_params["params"]) == len(group_params["param_names"])
+
+        if len(param_names) == 0:
+            logger.warning(
+                f'Notice: No parameters found for `str_match` "{str_match}" on '
+                f"global rank {torch.distributed.get_rank()}"
+            )
+            continue
+        group_params.update(group_config)
+        params.append(group_params)
+
+    # Add remaining parameters as the default group
+    param_names = list(param_dict.keys())
+    if param_names:
+        default_group = {
+            "params": [param_dict.pop(n) for n in param_names],
+            "param_names": param_names,
+        }
+        # Add default configuration to the default group
+        default_group.update(default_config)
+        params.insert(0, default_group)
+
+    # Create clean kwargs for the optimizer (remove extra_param_group_split_rules)
+    clean_kwargs = optimizer_kwargs.copy()
+    clean_kwargs.pop("extra_param_group_split_rules", None)
+
+    return params, clean_kwargs

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -674,10 +674,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         extra_metrics.update(self.optimizers.get_lrs())
 
         if need_to_calculate_norm:
-            # TODO(JSC)-Fixed: Notice that the original Gradient norm-log's LR is
-            #                  always one step behind the actual LR.
-            #                  Dist-scion can now calculate the norm at
-            #                  current step - synced LR.
             param_norms = self.optimizers.get_parameter_norms()
             extra_metrics.update(param_norms)
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -442,10 +442,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 json.dump(config_dict, f, indent=4)
 
             clean_config_dict = {}
-            for (header, subdict) in config_dict.items():
+            for header, subdict in config_dict.items():
                 clean_subdict = {}
                 clean_config_dict[header] = clean_subdict
-                for (key, value) in subdict.items():
+                for key, value in subdict.items():
                     if value is not None:
                         clean_subdict[key] = value
 


### PR DESCRIPTION
need merge https://github.com/janEbert/torchtitan/pull/26 first


So we provided two init functions from optimizer.distributed_scion to help init, no redundant code in upstream/component/optimizer.py

And we no longer take lots of configs to init. Instead, we can add them to a list

```
[[optimizer.extra_splits_rules]]
str_match = "tok_embeddings.weight"
norm_factor = "embed_sqrt"
backend = "identity"

[[optimizer.extra_splits_rules]]
str_match = "output.weight"
norm_factor = "unembed_sqrt"
backend = "identity"

[[optimizer.extra_splits_rules]]
str_match = "\\.router.gate.weight"
norm_factor = "spectral"

[[optimizer.extra_splits_rules]]
str_match = "ssnorm_scale"
norm_factor = "sign"
backend = "identity"
```