### PR TITLE
Trustllm 0.2 patching

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -698,7 +698,11 @@ def build_optimizers_with_moe_load_balancing(
             for block in part.layers.values():
                 if not block.moe_enabled:
                     continue
+<<<<<<< HEAD
                 moe = block.moe
+=======
+                moe = getattr(block, "moe", block.moe)
+>>>>>>> 4d91dce9 (sync some upstream changes.  and rename .ffn of moe to .moe align up steram,  re-use the apply_FSDP from llama4 for our model)
                 # Assuming num_experts is the same for all, so we can just grab it once
                 num_experts = moe.tokens_per_expert.numel()
                 moe_layers_info.append(

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -55,7 +55,7 @@ class Metrics:
     log all available norms. If "default" is specified, use the following:
     - "rms_to_rms"
     - "l1_to_rms"
-    - "rms_to_l1"
+    - "rms_to_inf"
     - "supremum"
     - "condition_number"
     """
@@ -144,7 +144,7 @@ class Model:
     factors.
     """
 
-    init_gate_as_residual = True
+    init_gate_as_residual: bool = True
     """Whether to initialize the GLU gate as if it was a residual layer."""
 
     final_out_init_fn_type: str = "trunc_normal"

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -796,7 +796,7 @@ class Transformer(nn.Module, ModelProtocol):
             if self.norm and prev_embed is None:
                 prev_embed = h
 
-            for (mtp_layer_id, mtp_layer) in self.mtp_layers.items():
+            for mtp_layer_id, mtp_layer in self.mtp_layers.items():
                 mtp_layer_id = int(mtp_layer_id)
                 token_offset = mtp_layer_id + 1
                 output, prev_embed = mtp_layer(

--- a/torchtitan/optimizers/norm_helper.py
+++ b/torchtitan/optimizers/norm_helper.py
@@ -41,7 +41,7 @@ def l1_to_rms_norm(W):
 
 
 @torch.no_grad()
-def rms_to_l1_norm(W):
+def rms_to_inf_norm(W):
     assert W.ndim == 2, "operator norm can only be applied to matrices"
     norm = torch.max(
         torch.linalg.norm(W.to(torch.float32), ord=2, dim=1, dtype=torch.float32)
@@ -96,7 +96,7 @@ def effective_rank(W):
 NORM_FUNCTIONS = {
     "rms_to_rms": rms_to_rms_norm,
     "l1_to_rms": l1_to_rms_norm,
-    "rms_to_l1": rms_to_l1_norm,
+    "rms_to_inf": rms_to_inf_norm,
     "supremum": supremum_norm,
     "condition_number": condition_number,
     "frobenius_norm": frobenius_norm,
@@ -125,7 +125,7 @@ def fused_metrics(W, eps=1e-20):
     col_l2 = colsqsum.sqrt()
 
     l1_to_rms = col_l2.max() / math.sqrt(fan_out)
-    rms_to_l1 = row_l2.max() * math.sqrt(fan_in)
+    rms_to_inf = row_l2.max() * math.sqrt(fan_in)
 
     S = torch.linalg.svdvals(Wf, driver="gesvd")
 
@@ -148,7 +148,7 @@ def fused_metrics(W, eps=1e-20):
     return {
         "rms_to_rms": spec,
         "l1_to_rms": l1_to_rms,
-        "rms_to_l1": rms_to_l1,
+        "rms_to_inf": rms_to_inf,
         "supremum": sup,
         "condition_number": cond,
         "frobenius_norm": frob_norm,
@@ -163,7 +163,7 @@ def get_norms_to_log(norms_to_log: str | list[str]) -> list[str]:
     Return a list of norms to log.
     The following contents in `norms_to_log` are special:
     - "default": replaced by
-                 ["rms_to_rms", "l1_to_rms", "rms_to_l1", "supremum", "condition_number"]
+                 ["rms_to_rms", "l1_to_rms", "rms_to_inf", "supremum", "condition_number"]
     - "all" or "everything": log all norms
     """
     if isinstance(norms_to_log, str):
@@ -182,7 +182,7 @@ def get_norms_to_log(norms_to_log: str | list[str]) -> list[str]:
             + [
                 "rms_to_rms",
                 "l1_to_rms",
-                "rms_to_l1",
+                "rms_to_inf",
                 "supremum",
                 "condition_number",
             ]

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -442,10 +442,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 json.dump(config_dict, f, indent=4)
 
             clean_config_dict = {}
-            for (header, subdict) in config_dict.items():
+            for header, subdict in config_dict.items():
                 clean_subdict = {}
                 clean_config_dict[header] = clean_subdict
-                for (key, value) in subdict.items():
+                for key, value in subdict.items():
                     if value is not None:
                         clean_subdict[key] = value
 


### PR DESCRIPTION
fix some code (adapting upstream changes)

rename model.block.ffn -> model.block.moe for moe layers.  such that we can use apply_fsdp from llama4.
(add special condition in scion that when {FSDP * EP} > experts, raise error.   i.e. `shard(1)` exists in Experts paramters)


Add conv to scion.

Correction,  it should technically be "RMS->INF" 